### PR TITLE
Feature/razee full uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,24 +170,28 @@ delete-resources: ## delete-resources
 
 delete: ##delete the contents created in 'make create'
 	@echo deleting resources
-	- kubectl delete opsrc ${OPERATOR_SOURCE} -n ${NAMESPACE}
+	- kubectl delete opsrc ${OPERATOR_SOURCE} -n openshift-marketplace
 	- kubectl delete -f deploy/crds/marketplace.redhat.com_v1alpha1_marketplaceconfig_cr.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/crds/marketplace.redhat.com_v1alpha1_razeedeployment_cr.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/crds/marketplace.redhat.com_v1alpha1_meterbase_cr.yaml -n ${NAMESPACE}
-	- kubectl delete -f deploy/crds/marketplace.redhat.com_v1alpha1_meterdefinitions_cr.yaml -n ${NAMESPACE}
+	- kubectl delete -f deploy/crds/marketplace.redhat.com_v1alpha1_meterdefinition_cr.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/operator.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/role_binding.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/role.yaml -n ${NAMESPACE}
 	- kubectl delete -f deploy/service_account.yaml -n ${NAMESPACE}
-	- kubectl delete -f deploy/crds/marketplace.redhat.com_marketplaceconfigs_crd.yaml -n ${NAMESPACE}
-	- kubectl delete -f deploy/crds/marketplace.redhat.com_razeedeployments_crd.yaml -n ${NAMESPACE}
-	- kubectl delete -f deploy/crds/marketplace.redhat.com_meterbases_crd.yaml -n ${NAMESPACE}
-	- kubectl delete -f deploy/crds/marketplace.redhat.com_meterdefinitions_crd.yaml -n ${NAMESPACE}
-	- kubectl delete namespace razee
+	- kubectl delete -f deploy/crds/marketplace.redhat.com_marketplaceconfigs_crd.yaml
+	- kubectl delete -f deploy/crds/marketplace.redhat.com_razeedeployments_crd.yaml
+	- kubectl delete -f deploy/crds/marketplace.redhat.com_meterbases_crd.yaml
+	- kubectl delete -f deploy/crds/marketplace.redhat.com_meterdefinitions_crd.yaml
+	- kubectl delete namespace ${NAMESPACE}
 
 delete-razee: ##delete the razee CR
 	@echo deleting razee CR
 	- kubectl delete -f  deploy/crds/marketplace.redhat.com_v1alpha1_razeedeployment_cr.yaml -n ${NAMESPACE}
+
+create-razee: ##create the razee CR
+	@echo creating razee CR
+	- kubectl create -f  deploy/crds/marketplace.redhat.com_v1alpha1_razeedeployment_cr.yaml -n ${NAMESPACE}
 
 ##@ Tests
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -132,6 +132,21 @@ roles:
           - patch
           - update
       - apiGroups:
+          - apiextensions.k8s.io
+        resources:
+          - customresourcedefinitions
+        resourceNames:
+          - remoteresources.deploy.razee.io
+          - remoteresourcess3.deploy.razee.io
+          - featureflagsetsld.deploy.razee.io
+          - managedsets.deploy.razee.io
+          - mustachetemplates.deploy.razee.io
+          - remoteresourcess3decrypt.deploy.razee.io
+        verbs:
+          - get
+          - list
+          - delete
+      - apiGroups:
           - config.openshift.io
         resources:
           - consoles

--- a/deploy/crds/marketplace.redhat.com_v1alpha1_razeedeployment_cr.yaml
+++ b/deploy/crds/marketplace.redhat.com_v1alpha1_razeedeployment_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: marketplace.redhat.com/v1alpha1
 kind: RazeeDeployment
 metadata:
-  name: example-razeedeployment
+  name: rhm-marketplaceconfig-razeedeployment
 spec:
   # Add fields here
   enabled: true

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	google.golang.org/appengine v1.6.6 // indirect
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3
-	k8s.io/apiextensions-apiserver v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 	sigs.k8s.io/controller-runtime v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	google.golang.org/appengine v1.6.6 // indirect
 	k8s.io/api v0.18.3
 	k8s.io/apimachinery v0.18.3
+	k8s.io/apiextensions-apiserver v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 	sigs.k8s.io/controller-runtime v0.6.0

--- a/pkg/controller/razeedeployment/razeedeployment_controller_test.go
+++ b/pkg/controller/razeedeployment/razeedeployment_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -71,7 +70,7 @@ func newUnstructured(apiVersion, kind, namespace, name string) *unstructured.Uns
 
 func setup(r *ReconcilerTest) error {
 	r.SetClient(fake.NewFakeClient(r.GetGetObjects()...))
-	r.SetReconciler(&ReconcileRazeeDeployment{client: r.GetClient(), scheme: scheme.Scheme, opts: &RazeeOpts{RazeeJobImage: "test"}, config: &rest.Config{}})
+	r.SetReconciler(&ReconcileRazeeDeployment{client: r.GetClient(), scheme: scheme.Scheme, opts: &RazeeOpts{RazeeJobImage: "test"}})
 	return nil
 }
 


### PR DESCRIPTION
Issue: https://github.ibm.com/symposium/track-and-plan/issues/6518

**What changed:**
When delete a razeeDeployment resource, we also delete the following resources created by razeeDeployment:
- the old install job (with its related pod)
- CRs
- configmaps
- secrets
- serviceaccounts
- deployments

Note: due to the bug in fakeClient https://github.com/kubernetes-sigs/controller-runtime/issues/702, we skipped the test case for custom resource deletion.