### PR TITLE
add operator-sdk commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 PULL_POLICY ?= IfNotPresent
 .DEFAULT_GOAL := help
 
+# cluster server to test the rhm operator
+CLUSTER_SERVER ?= https://api.crc.testing:6443
+# The namespace where the operator watches for changes. Set "" for AllNamespaces, set "ns1,ns2" for MultiNamespace
+OPERATOR_WATCH_NAMESPACE ?= ""
+
 ##@ Application
 
 install: ## Install all resources (CR/CRD's, RBAC and Operator)
@@ -141,6 +146,15 @@ setup-minikube: ## Setup minikube for full operator dev
 		kubectl apply -f https://raw.githubusercontent.com/kubernetes/kube-state-metrics/master/examples/standard/$$item ; \
 	done
 
+setup-operator-sdk-run: ## Create ns, crds, sa, role, and rolebinding before operator-sdk run
+	make helm
+	make create
+	make deploy-services
+	. ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
+
+operator-sdk-run: ## Run operator locally outside the cluster during development cycle
+	operator-sdk run --local --watch-namespace=$(OPERATOR_WATCH_NAMESPACE) --kubeconfig=./sa.kubeconfig
+
 ##@ Manual Testing
 
 create: ##creates the required crds for this deployment
@@ -153,10 +167,13 @@ create: ##creates the required crds for this deployment
 
 deploys: ##deploys the resources for deployment
 	@echo deploying services and operators
+	- make deploy-services
+	- kubectl create -f deploy/operator.yaml --namespace=${NAMESPACE}
+
+deploy-services: ##deploys the service acconts, roles, and role bindings
 	- kubectl create -f deploy/service_account.yaml --namespace=${NAMESPACE}
 	- kubectl create -f deploy/role.yaml --namespace=${NAMESPACE}
 	- kubectl create -f deploy/role_binding.yaml --namespace=${NAMESPACE}
-	- kubectl create -f deploy/operator.yaml --namespace=${NAMESPACE}
 
 apply: ##applies changes to crds
 	- kubectl apply -f deploy/crds/marketplace.redhat.com_v1alpha1_marketplaceconfig_cr.yaml --namespace=${NAMESPACE}

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,10 @@ setup-minikube: ## Setup minikube for full operator dev
 	done
 
 setup-operator-sdk-run: ## Create ns, crds, sa, role, and rolebinding before operator-sdk run
-	make helm
-	make create
-	make deploy-services
-	. ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
+	- make helm
+	- make create
+	- make deploy-services
+	- . ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
 
 operator-sdk-run: ## Run operator locally outside the cluster during development cycle
 	operator-sdk run --local --watch-namespace=$(OPERATOR_WATCH_NAMESPACE) --kubeconfig=./sa.kubeconfig

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -132,7 +132,7 @@ make test-e2e
 ```
 
 
-## Lcoal Developmetn
+## Local Development
 
 ### Developing with Skaffold (automatic)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,7 @@ for installs and you'll need to install that operator by hand.
 ### Building
 
 ```sh
-# Builds the executable
+# Builds the executable and packages the docker image
  make build
 ```
 
@@ -113,6 +113,7 @@ make build uninstall install
 
 ```
 
+
 ### Testing
 
 ```sh
@@ -131,7 +132,9 @@ make test-e2e
 ```
 
 
-## Developing with Skaffold (automatic)
+## Lcoal Developmetn
+
+### Developing with Skaffold (automatic)
 
 For a faster dev experience you may enjoy skaffold.
 
@@ -145,4 +148,14 @@ make skaffold-dev
 
 # Run skaffold in run mode, will not watch changes
 make skaffold-run
+```
+
+### Running locally using operator-sdk (automatic)
+
+This is a very fast method of rebuilding locally. It uses the same roles as the real operator by supplying a kubeconfig to the operator-sdk run command.
+
+This is recommended if you do not want to pull and push images to remote registries.
+
+```sh
+make setup-operator-sdk-run operator-sdk-run
 ```

--- a/scripts/operator_sdk_sa_kubeconfig.sh
+++ b/scripts/operator_sdk_sa_kubeconfig.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+server=$1
+namespace=$2
+saname=$3
+
+# the name of the secret containing the service account token
+secretname=$(kubectl get sa/$saname -n $namespace -o json | jq -r '.secrets[].name' | grep redhat-marketplace-operator-token)
+
+ca=$(kubectl get secret/$secretname -n $namespace -o jsonpath='{.data.ca\.crt}')
+token=$(kubectl get secret/$secretname -n $namespace -o jsonpath='{.data.token}' | base64 --decode)
+
+echo "
+apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    certificate-authority-data: ${ca}
+    server: ${server}
+contexts:
+- name: rhm-operator-context
+  context:
+    cluster: default-cluster
+    namespace: ${namespace}
+    user: rhm-operator-sa
+current-context: rhm-operator-context
+users:
+- name: rhm-operator-sa
+  user:
+    token: ${token}
+" > sa.kubeconfig

--- a/scripts/operator_sdk_sa_kubeconfig.sh
+++ b/scripts/operator_sdk_sa_kubeconfig.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -euo pipefail
 
 server=$1
 namespace=$2
@@ -8,6 +9,7 @@ saname=$3
 secretname=$(kubectl get sa/$saname -n $namespace -o json | jq -r '.secrets[].name' | grep redhat-marketplace-operator-token)
 
 ca=$(kubectl get secret/$secretname -n $namespace -o jsonpath='{.data.ca\.crt}')
+
 token=$(kubectl get secret/$secretname -n $namespace -o jsonpath='{.data.token}' | base64 --decode)
 
 echo "

--- a/scripts/scorecard_with_kind.sh
+++ b/scripts/scorecard_with_kind.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+VERSION=${VERSION:-$(make current-version)}
+FILTER=${FILTER:-""}
+CLUSTER_NAME=${CLUSTER_NAME:-'operator-test'}
+OUR_CLUSTER=$(kind get clusters | grep "$CLUSTER_NAME")
+CRS=$(find './deploy/crds/' | grep -E '_cr.yaml$')
+
+if [ "$OUR_CLUSTER" != "" ]; then
+	kind delete cluster --name "$CLUSTER_NAME"
+fi
+
+if [ "$FILTER" != "" ]; then
+    CRS=$(echo "$CRS" | grep -E "$FILTER")
+fi
+
+echo "Testing $CRS"
+
+for cr in $CRS; do
+	kind create cluster --name "$CLUSTER_NAME"
+  yq w .osdk-scorecard.yaml.tpl 'scorecard.plugins.*.*.cr-manifest.+' "$cr" > .osdk-scorecard.yaml
+  yq w -i .osdk-scorecard.yaml 'scorecard.plugins.*.*.csv-path' deploy/olm-catalog/redhat-marketplace-operator/${VERSION}/redhat-marketplace-operator.v${VERSION}.clusterserviceversion.yaml
+
+  ./scripts/scorecard.sh
+
+	kind delete cluster --name "$CLUSTER_NAME"
+done


### PR DESCRIPTION
Separated setup-operator-sdk-run and operator-sdk-run. Then we can re-run `make operator-sdk-run` to catch the latest code changes without re-creating ns, sa, role,...