### PR TITLE
fix: RazeeDeployment no longer reconciles when any secret is deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ setup-operator-sdk-run: ## Create ns, crds, sa, role, and rolebinding before ope
 	- . ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
 
 operator-sdk-run: ## Run operator locally outside the cluster during development cycle
-	operator-sdk run --local --watch-namespace=$(OPERATOR_WATCH_NAMESPACE) --kubeconfig=./sa.kubeconfig
+	operator-sdk run local --watch-namespace="" --kubeconfig=./sa.kubeconfig
 
 ##@ Manual Testing
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,10 +78,13 @@ rules:
   - operators.coreos.com
   resources:
   - subscriptions
+  - installplans
+  - clusterserviceversions
   verbs:
   - get
   - list
   - watch
+  - delete
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -6,7 +6,7 @@ metadata:
   name: redhat-marketplace-operator
   labels:
     redhat.marketplace.com/name: redhat-marketplace-operator
-    redhat.marketplace.com/version: 0.1.2
+    redhat.marketplace.com/version: 0.1.4
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/service_account.yaml
 apiVersion: v1
@@ -15,4 +15,4 @@ metadata:
   name: redhat-marketplace-razeedeploy
   labels:
     redhat.marketplace.com/name: redhat-marketplace-operator
-    redhat.marketplace.com/version: 0.1.2
+    redhat.marketplace.com/version: 0.1.4

--- a/pkg/controller/razeedeployment/razeedeployment_controller.go
+++ b/pkg/controller/razeedeployment/razeedeployment_controller.go
@@ -115,6 +115,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Find secret
 	p := predicate.Funcs{
+		// Ensures RazeeDeployment is only reconciled for appropriate Secrets
+		// And not any secrets, regardless of namespace
+
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			label, _ := utils.GetMapKeyValue(utils.LABEL_RHM_OPERATOR_WATCH)
 			// The object doesn't contain label "foo", so the event will be
@@ -131,6 +134,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			if e.Meta.GetName() == utils.RHM_OPERATOR_SECRET_NAME {
 				return true
 			}
+
+			if _, ok := e.Meta.GetLabels()[label]; !ok {
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			label, _ := utils.GetMapKeyValue(utils.LABEL_RHM_OPERATOR_WATCH)
 
 			if _, ok := e.Meta.GetLabels()[label]; !ok {
 				return false


### PR DESCRIPTION
[Addresses razeedeployment continuously queue for reconcile](https://github.ibm.com/symposium/track-and-plan/issues/7495)

Previously RazeeDeployment would reconcile when any secret (regardless of namespace / affiliation) was deleted. Added to ```predicate.Funcs``` to only reconcile when appropriate secrets are deleted. 

**How to Test**

* `make setup-operator-sdk-run operator-sdk-run`
* Create then delete the following resource:
```
apiVersion: v1
kind: Namespace
metadata:
  name: my-etcd-1
---
apiVersion: operators.coreos.com/v1alpha2
kind: OperatorGroup
metadata:
  name: operatorgroup
  namespace: my-etcd-1
spec:
  targetNamespaces:
  - my-etcd-1
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: etcd
  namespace: my-etcd-1
spec:
  channel: singlenamespace-alpha
  installPlanApproval: Automatic
  name: etcd
  source: community-operators
  sourceNamespace: openshift-marketplace
```
* RazeeDeployment should no longer reconcile

**Note:** you can also test with a simple secret ex.
```
apiVersion: v1
kind: Namespace
metadata:
  name: fakeNs
---
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
  namespace: fakeNs
type: Opaque
data:
  username: user
  password: pass
```
