### PR TITLE
chore: add update to dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,6 +28,10 @@ LABEL name="Red Hat Marketplace Operator" \
   summary="Red Hat Marketplace Operator Image" \
   description="Operator for the Red Hat Marketplace"
 
+RUN microdnf update --setopt=tsflags=nodocs -y \
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
+
 ENV USER_UID=1001 \
     USER_NAME=redhat-marketplace-operator \
     ASSETS=/usr/local/bin/assets


### PR DESCRIPTION
Our images are being flagged for a high vulnerability. This will fix it and make sure updates are made on top of the ubi minimal image we use as a base.