### PR TITLE
Feature/add CSV controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ setup-operator-sdk-run: ## Create ns, crds, sa, role, and rolebinding before ope
 	- . ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
 
 operator-sdk-run: ## Run operator locally outside the cluster during development cycle
-	operator-sdk run local --watch-namespace="" --kubeconfig=./sa.kubeconfig
+	operator-sdk run --local --watch-namespace="" --kubeconfig=./sa.kubeconfig
 
 ##@ Manual Testing
 

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ setup-operator-sdk-run: ## Create ns, crds, sa, role, and rolebinding before ope
 	- . ./scripts/operator_sdk_sa_kubeconfig.sh $(CLUSTER_SERVER) $(NAMESPACE) $(SERVICE_ACCOUNT)
 
 operator-sdk-run: ## Run operator locally outside the cluster during development cycle
-	operator-sdk run --local --watch-namespace="" --kubeconfig=./sa.kubeconfig
+	operator-sdk run local --watch-namespace="" --kubeconfig=./sa.kubeconfig
 
 ##@ Manual Testing
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ func makeMarketplaceController(
 	meterDefinitionC *controller.MeterDefinitionController,
 	razeeC *controller.RazeeDeployController,
 	olmSubscriptionC *controller.OlmSubscriptionController,
+	olmClusterServiceVersionC *controller.OlmClusterServiceVersionController,
 	nodeC *controller.NodeController,
 	controllerFlags *controller.ControllerFlagSet,
 	opsSrcScheme *managers.OpsSrcSchemeDefinition,
@@ -53,6 +54,7 @@ func makeMarketplaceController(
 			(*controller.ControllerDefinition)(meterDefinitionC),
 			(*controller.ControllerDefinition)(razeeC),
 			(*controller.ControllerDefinition)(olmSubscriptionC),
+			(*controller.ControllerDefinition)(olmClusterServiceVersionC),
 			(*controller.ControllerDefinition)(nodeC),
 		},
 		Schemes: []*managers.SchemeDefinition{

--- a/cmd/manager/wire_gen.go
+++ b/cmd/manager/wire_gen.go
@@ -18,12 +18,13 @@ func initializeMarketplaceController() *managers.ControllerMain {
 	meterDefinitionController := controller.ProvideMeterDefinitionController()
 	razeeDeployController := controller.ProvideRazeeDeployController()
 	olmSubscriptionController := controller.ProvideOlmSubscriptionController()
+	olmClusterServiceVersionController := controller.ProvideOlmClusterServiceVersionController()
 	nodeController := controller.ProvideNodeController()
 	controllerFlagSet := controller.ProvideControllerFlagSet()
 	opsSrcSchemeDefinition := managers.ProvideOpsSrcScheme()
 	monitoringSchemeDefinition := managers.ProvideMonitoringScheme()
 	olmV1SchemeDefinition := managers.ProvideOLMV1Scheme()
 	olmV1Alpha1SchemeDefinition := managers.ProvideOLMV1Alpha1Scheme()
-	controllerMain := makeMarketplaceController(marketplaceController, meterbaseController, meterDefinitionController, razeeDeployController, olmSubscriptionController, nodeController, controllerFlagSet, opsSrcSchemeDefinition, monitoringSchemeDefinition, olmV1SchemeDefinition, olmV1Alpha1SchemeDefinition)
+	controllerMain := makeMarketplaceController(marketplaceController, meterbaseController, meterDefinitionController, razeeDeployController, olmSubscriptionController, olmClusterServiceVersionController, nodeController, controllerFlagSet, opsSrcSchemeDefinition, monitoringSchemeDefinition, olmV1SchemeDefinition, olmV1Alpha1SchemeDefinition)
 	return controllerMain
 }

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -94,9 +94,11 @@ roles:
           - operators.coreos.com
         resources:
           - subscriptions
+          - clusterserviceversions
         verbs:
           - get
           - list
+          - update
           - watch
       - apiGroups:
           - operators.coreos.com

--- a/pkg/controller/add_clusterserviceversion.go
+++ b/pkg/controller/add_clusterserviceversion.go
@@ -15,22 +15,15 @@
 package controller
 
 import (
-	"github.com/google/wire"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/pkg/controller/clusterserviceversion"
 	"github.com/spf13/pflag"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-type ControllerDefinition struct {
-	Add     func(mgr manager.Manager) error
-	FlagSet func() *pflag.FlagSet
+type OlmClusterServiceVersionController ControllerDefinition
+
+func ProvideOlmClusterServiceVersionController() *OlmClusterServiceVersionController {
+	return &OlmClusterServiceVersionController{
+		Add:     clusterserviceversion.Add,
+		FlagSet: func() *pflag.FlagSet { return nil },
+	}
 }
-
-var ControllerSet = wire.NewSet(
-	ProvideMarketplaceController,
-	ProvideMeterbaseController,
-	ProvideRazeeDeployController,
-	ProvideMeterDefinitionController,
-	ProvideOlmSubscriptionController,
-	ProvideNodeController,
-	ProvideOlmClusterServiceVersionController,
-)

--- a/pkg/controller/clusterserviceversion/clusterserviceversion_controller.go
+++ b/pkg/controller/clusterserviceversion/clusterserviceversion_controller.go
@@ -1,0 +1,160 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterserviceversion
+
+import (
+	"context"
+	"reflect"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_olm_clusterserviceversion_watcher")
+
+const operatorTag = "marketplace.redhat.com/operator"
+const watchTag = "razee/watch-resource"
+const allnamespaceTag = "olm.copiedFrom"
+
+// Add creates a new ClusterServiceVersion Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileClusterServiceVersion{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("clusterserviceversion-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	labelPreds := []predicate.Predicate{
+		predicate.Funcs{
+			UpdateFunc: func(evt event.UpdateEvent) bool {
+				return false
+			},
+			CreateFunc: func(evt event.CreateEvent) bool {
+				if _, ok := evt.Meta.GetLabels()[allnamespaceTag]; ok {
+					return false
+				}
+				return true
+			},
+			GenericFunc: func(evt event.GenericEvent) bool {
+				return false
+			},
+		},
+	}
+
+	// Watch for changes to primary resource ClusterServiceVersion
+	err = c.Watch(&source.Kind{Type: &olmv1alpha1.ClusterServiceVersion{}}, &handler.EnqueueRequestForObject{}, labelPreds...)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// blank assignment to verify that ReconcileClusterServiceVersion implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileClusterServiceVersion{}
+
+// ReconcileClusterServiceVersion reconciles a ClusterServiceVersion object
+type ReconcileClusterServiceVersion struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a ClusterServiceVersion object and makes changes based on the state read
+// and what is in the ClusterServiceVersion.Spec
+func (r *ReconcileClusterServiceVersion) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Name", request.Name)
+	reqLogger.Info("Reconciling ClusterServiceVersion")
+	// Fetch the ClusterServiceVersion instance
+	CSV := &olmv1alpha1.ClusterServiceVersion{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, CSV)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			reqLogger.Error(err, "clusterserviceversion does not exist")
+			return reconcile.Result{}, nil
+		}
+		reqLogger.Error(err, "Failed to get clusterserviceversion")
+		return reconcile.Result{}, err
+	}
+
+	sub := &olmv1alpha1.SubscriptionList{}
+
+	if err = r.client.List(context.TODO(), sub, client.InNamespace(request.NamespacedName.Namespace)); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	reqLogger.Info("found Subscription in namespaces", "count", len(sub.Items))
+
+	if len(sub.Items) > 0 {
+		// add razee watch label to CSV if subscription has
+		for _, s := range sub.Items {
+			if value, ok := s.GetLabels()[operatorTag]; ok {
+				if value == "true" {
+					if s.Status.InstalledCSV == request.NamespacedName.Name {
+						reqLogger.Info("found Subscription with installed CSV")
+						labels := CSV.GetLabels()
+						if labels == nil {
+							labels = make(map[string]string)
+						}
+						clusterOriginalLabels := CSV.DeepCopy().GetLabels()
+						labels[watchTag] = "lite"
+						if !reflect.DeepEqual(labels, clusterOriginalLabels) {
+							CSV.SetLabels(labels)
+							if err := r.client.Update(context.TODO(), CSV); err != nil {
+								reqLogger.Error(err, "Failed to patch clusterserviceversion with razee/watch-resource: lite label")
+								return reconcile.Result{}, err
+							}
+							reqLogger.Info("Patched clusterserviceversion with razee/watch-resource: lite label")
+						} else {
+							reqLogger.Info("No patch needed on clusterserviceversion resource")
+						}
+					}
+				}
+			}
+		}
+		return reconcile.Result{}, nil
+	}
+
+	reqLogger.Info("reconcilation complete")
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/clusterserviceversion/clusterserviceversion_controller.go
+++ b/pkg/controller/clusterserviceversion/clusterserviceversion_controller.go
@@ -65,6 +65,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			UpdateFunc: func(evt event.UpdateEvent) bool {
 				return false
 			},
+			DeleteFunc: func(evt event.DeleteEvent) bool {
+				return false
+			},
 			CreateFunc: func(evt event.CreateEvent) bool {
 				if _, ok := evt.Meta.GetLabels()[allnamespaceTag]; ok {
 					return false

--- a/pkg/controller/clusterserviceversion/clusterserviceversion_controller_test.go
+++ b/pkg/controller/clusterserviceversion/clusterserviceversion_controller_test.go
@@ -1,0 +1,175 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterserviceversion
+
+import (
+	"testing"
+
+	. "github.com/redhat-marketplace/redhat-marketplace-operator/test/rectest"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func TestClusterServiceVersionController(t *testing.T) {
+
+	logf.SetLogger(logf.ZapLogger(true))
+	_ = olmv1alpha1.AddToScheme(scheme.Scheme)
+
+	t.Run("Test New Cluster Service Version with installed CSV", testClusterServiceVersionWithInstalledCSV)
+	t.Run("Test New Cluster Service Version without installed CSV", testClusterServiceVersionWithoutInstalledCSV)
+	t.Run("Test New Cluster Service Version with Sub without labels", testClusterServiceVersionWithSubscriptionWithoutLabels)
+}
+
+var (
+	csvName   = "new-clusterserviceversion"
+	subName   = "new-subscription"
+	namespace = "arbitrary-namespace"
+
+	req = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      csvName,
+			Namespace: namespace,
+		},
+	}
+	opts = []StepOption{
+		WithRequest(req),
+	}
+
+	clusterserviceversion = &olmv1alpha1.ClusterServiceVersion{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      csvName,
+			Namespace: namespace,
+		},
+	}
+	subscription = &olmv1alpha1.Subscription{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      subName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				operatorTag: "true",
+			},
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: csvName,
+		},
+	}
+
+	subscriptionWithoutLabels = &olmv1alpha1.Subscription{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      subName,
+			Namespace: namespace,
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: csvName,
+		},
+	}
+
+	subscriptionDifferentCSV = &olmv1alpha1.Subscription{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      subName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				operatorTag: "true",
+			},
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: "dummy",
+		},
+	}
+)
+
+func setup(r *ReconcilerTest) error {
+	r.Client = fake.NewFakeClient(r.GetGetObjects()...)
+	r.Reconciler = &ReconcileClusterServiceVersion{client: r.Client, scheme: scheme.Scheme}
+	return nil
+}
+
+func testClusterServiceVersionWithInstalledCSV(t *testing.T) {
+	t.Parallel()
+	reconcilerTest := NewReconcilerTest(setup, clusterserviceversion, subscription)
+	reconcilerTest.TestAll(t,
+		ReconcileStep(opts,
+			ReconcileWithExpectedResults(DoneResult)),
+		ListStep(opts,
+			ListWithObj(&olmv1alpha1.ClusterServiceVersionList{}),
+			ListWithFilter(
+				client.InNamespace(namespace),
+				client.MatchingLabels(map[string]string{
+					watchTag: "lite",
+				})),
+			ListWithCheckResult(func(r *ReconcilerTest, t *testing.T, i runtime.Object) {
+				list, ok := i.(*olmv1alpha1.ClusterServiceVersionList)
+
+				assert.Truef(t, ok, "expected cluster service version list got type %T", i)
+				assert.Equal(t, 1, len(list.Items))
+			}),
+		),
+	)
+}
+
+func testClusterServiceVersionWithoutInstalledCSV(t *testing.T) {
+	t.Parallel()
+	reconcilerTest := NewReconcilerTest(setup, clusterserviceversion, subscriptionDifferentCSV)
+	reconcilerTest.TestAll(t,
+		ReconcileStep(nil,
+			ReconcileWithExpectedResults(DoneResult)),
+		ListStep(nil,
+			ListWithObj(&olmv1alpha1.ClusterServiceVersionList{}),
+			ListWithFilter(
+				client.InNamespace(namespace),
+				client.MatchingLabels(map[string]string{
+					watchTag: "lite",
+				})),
+			ListWithCheckResult(func(r *ReconcilerTest, t *testing.T, i runtime.Object) {
+				list, ok := i.(*olmv1alpha1.ClusterServiceVersionList)
+
+				assert.Truef(t, ok, "expected cluster service version list got type %T", i)
+				assert.Equal(t, 0, len(list.Items))
+			}),
+		),
+	)
+}
+
+func testClusterServiceVersionWithSubscriptionWithoutLabels(t *testing.T) {
+	t.Parallel()
+	reconcilerTest := NewReconcilerTest(setup, clusterserviceversion, subscriptionWithoutLabels)
+	reconcilerTest.TestAll(t,
+		ReconcileStep(opts,
+			ReconcileWithExpectedResults(DoneResult)),
+		ListStep(opts,
+			ListWithObj(&olmv1alpha1.ClusterServiceVersionList{}),
+			ListWithFilter(
+				client.InNamespace(namespace),
+				client.MatchingLabels(map[string]string{
+					watchTag: "lite",
+				})),
+			ListWithCheckResult(func(r *ReconcilerTest, t *testing.T, i runtime.Object) {
+				list, ok := i.(*olmv1alpha1.ClusterServiceVersionList)
+
+				assert.Truef(t, ok, "expected cluster service version list got type %T", i)
+				assert.Equal(t, 0, len(list.Items))
+			}),
+		),
+	)
+}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -134,6 +134,6 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 	} else {
 		reqLogger.Info("No patch needed on node resource")
 	}
-
+	reqLogger.Info("reconcilation complete")
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
Issue: https://github.ibm.com/symposium/track-and-plan/issues/7517

What changed:

Added a controller for CSV for adding label ["razee/watch-resource":"lite"] if subscription has rhm operator label
Updated the roles for ClusterServiceVersion resources
Not attaching razee watch label to the copied CSVs for allNamespace subscriptions