### PR TITLE
fix: delete rhm-metric-state-service on uninstall

### DIFF
--- a/pkg/controller/meterbase/meterbase_controller.go
+++ b/pkg/controller/meterbase/meterbase_controller.go
@@ -964,7 +964,7 @@ func (r *ReconcileMeterBase) uninstallMetricState(
 	factory *manifests.Factory,
 ) []ClientAction {
 	deployment, _ := factory.MetricStateDeployment()
-	service2, _ := factory.MetricStateService()
+	service, _ := factory.MetricStateService()
 	sm, _ := factory.MetricStateServiceMonitor()
 
 	return []ClientAction{
@@ -972,8 +972,8 @@ func (r *ReconcileMeterBase) uninstallMetricState(
 			GetAction(types.NamespacedName{Namespace: sm.Namespace, Name: sm.Name}, sm),
 			OnContinue(DeleteAction(sm))),
 		HandleResult(
-			GetAction(types.NamespacedName{Namespace: service2.Namespace, Name: service2.Name}, deployment),
-			OnContinue(DeleteAction(service2))),
+			GetAction(types.NamespacedName{Namespace: service.Namespace, Name: service.Name}, service),
+			OnContinue(DeleteAction(service))),
 		HandleResult(
 			GetAction(types.NamespacedName{Namespace: deployment.Namespace, Name: deployment.Name}, deployment),
 			OnContinue(DeleteAction(deployment))),


### PR DESCRIPTION
Quick bug-fix. Previously when deleting resources (meterbase, prometheus, rhm-metric-state), the service `rhm-metric-state-service`, wasn't being deleted. Now it should.