### PR TITLE
fix(reporter): more unique meter ID generation

### DIFF
--- a/pkg/reporter/builder.go
+++ b/pkg/reporter/builder.go
@@ -105,19 +105,25 @@ type MetricKey struct {
 	IntervalEnd       string `mapstructure:"interval_end"`
 	MeterDomain       string `mapstructure:"domain"`
 	MeterKind         string `mapstructure:"kind"`
-	MeterVersion      string `mapstructure:"version"`
+	MeterVersion      string `mapstructure:"version,omitempty"`
+	Workload          string `mapstructure:"workload,omitempty"`
+	Namespace         string `mapstructure:"namespace,omitempty"`
+	ResourceName      string `mapstructure:"resource_name,omitempty"`
 }
 
-func (k *MetricKey) Init(ClusterID, unit, namespace string) {
+func (k *MetricKey) Init(
+	clusterID string,
+) {
 	hash := xxhash.New()
 
-	hash.Write([]byte(ClusterID))
+	hash.Write([]byte(clusterID))
 	hash.Write([]byte(k.IntervalStart))
 	hash.Write([]byte(k.IntervalEnd))
 	hash.Write([]byte(k.MeterDomain))
 	hash.Write([]byte(k.MeterKind))
-	hash.Write([]byte(unit))
-	hash.Write([]byte(namespace))
+	hash.Write([]byte(k.Workload))
+	hash.Write([]byte(k.Namespace))
+	hash.Write([]byte(k.ResourceName))
 
 	k.MetricID = fmt.Sprintf("%x", hash.Sum64())
 }

--- a/pkg/reporter/builder_test.go
+++ b/pkg/reporter/builder_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Builder", func() {
 			MeterDomain:       "test",
 			MeterKind:         "foo",
 			MeterVersion:      "v1",
+			ResourceName:      "foo",
+			Namespace:         "bar",
+			Workload:          "awesome",
 		}
 		metricBase = &MetricBase{
 			Key: key,
@@ -53,9 +56,9 @@ var _ = Describe("Builder", func() {
 
 	It("should serialize source metadata to json", func() {
 		metadata := NewReportMetadata(uuid.New(), ReportSourceMetadata{
-			RhmClusterID: "testCluster",
+			RhmClusterID:   "testCluster",
 			RhmEnvironment: ReportSandboxEnv,
-			RhmAccountID: "testAccount",
+			RhmAccountID:   "testAccount",
 		})
 
 		metadata.AddMetricsReport(metricsReport)
@@ -90,6 +93,9 @@ var _ = Describe("Builder", func() {
 					"domain":              Equal("test"),
 					"version":             Equal("v1"),
 					"kind":                Equal("foo"),
+					"resource_name":       Equal("foo"),
+					"namespace":           Equal("bar"),
+					"workload":            Equal("awesome"),
 					"additionalLabels": MatchAllKeys(Keys{
 						"extra": Equal("g"),
 					}),

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -181,6 +181,7 @@ type meterDefPromModel struct {
 	model.Value
 	MetricName string
 	Type       v1alpha1.WorkloadType
+	Workload   v1alpha1.Workload
 }
 
 func (r *MarketplaceReporter) query(
@@ -239,7 +240,7 @@ func (r *MarketplaceReporter) query(
 					return
 				}
 
-				outPromModels <- meterDefPromModel{mdef, val, metric.Label, query.Type}
+				outPromModels <- meterDefPromModel{mdef, val, metric.Label, query.Type, workload}
 			}
 		}
 	}
@@ -307,7 +308,7 @@ func (r *MarketplaceReporter) process(
 						}
 
 						if objName == "" {
-							errorsch <- errors.New("can't fine objName")
+							errorsch <- errors.New("can't find objName")
 							return
 						}
 
@@ -318,9 +319,12 @@ func (r *MarketplaceReporter) process(
 							IntervalEnd:       pair.Timestamp.Add(time.Hour).Time().Format(time.RFC3339),
 							MeterDomain:       mdef.Spec.Group,
 							MeterKind:         mdef.Spec.Kind,
+							Namespace:         namespace,
+							ResourceName:      objName,
+							Workload:          pmodel.Workload.Name,
 						}
 
-						key.Init(r.mktconfig.Spec.ClusterUUID, objName, namespace)
+						key.Init(r.mktconfig.Spec.ClusterUUID)
 
 						mutex.Lock()
 						defer mutex.Unlock()


### PR DESCRIPTION
This PR will add a few fields to the meter report ID generation to make it more unique. Currently reruns will not happen if the meter report was updated.