### PR TITLE
support native build for base-base image on non amd64 architectures (using build-arg)

### DIFF
--- a/build/base.Dockerfile
+++ b/build/base.Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest as golang
 
-ENV VERSION=1.15.1 OS=linux ARCH=amd64
+ARG ARCH=amd64
+ENV VERSION=1.15.1 OS=linux ARCH=${ARCH}
 
 RUN dnf -y install git
 


### PR DESCRIPTION
The default ARCH is amd64.

The image can be built using below
docker build --build-arg ARCH=ppc64le -t quay.io/rh-marketplace/golang-base:1.15 -f build/base.Dockerfile .
on ppc64le

The ARCH of the built image
docker inspect quay.io/rh-marketplace/golang-base:1.15 | grep -i arch
                "ARCH=ppc64le"
                "architecture": "ppc64le",
                "ARCH=ppc64le"
                "architecture": "ppc64le",
        "Architecture": "ppc64le",

and the environment variable
docker run --rm=true -it quay.io/rh-marketplace/golang-base:1.15 bash
[root@1637d03cbdd6 /]# echo $ARCH
ppc64le

show up correctly.