### PR TITLE
prevent duplicate series for the match group

### DIFF
--- a/reporter/v2/pkg/reporter/query.go
+++ b/reporter/v2/pkg/reporter/query.go
@@ -197,7 +197,7 @@ type MeterDefinitionQuery struct {
 // Returns a set of elements without duplicates
 // Ignore labels such that a pod restart, meterdefinition recreate, or other labels do not generate a new unique element
 // Use max over time to get the meter definition most prevalent for the hour
-const meterDefinitionQueryStr = `max_over_time(((meterdef_metric_label_info{} + ignoring(container, endpoint, instance, job, meter_definition_uid, pod, service) meterdef_metric_label_info{}) or on() vector(0))[{{ .Step }}:{{ .Step }}])`
+const meterDefinitionQueryStr = `max_over_time(((max without (container, endpoint, instance, job, meter_definition_uid, pod, service) (meterdef_metric_label_info{})) or on() vector(0))[{{ .Step }}:{{ .Step }}])`
 
 var meterDefinitionQueryTemplate *template.Template = utils.Must(func() (interface{}, error) {
 	return template.New("meterDefinitionQuery").Parse(meterDefinitionQueryStr)


### PR DESCRIPTION
Edge case
- multiple rhm-metric-state pods end up running 
- duplicate time series are produced with a different pod/instance tag

Results in reporter/prometheus error
- found duplicate series for the match group
- many-to-many matching not allowed: matching labels must be unique on one side

The new query string should still remove the extraneous labels, and compact the result into a set of non-duplicate active meter definitions