### PR TITLE
basicAuth for kubeVersion lt 1.20.0

### DIFF
--- a/reporter/v2/cmd/reporter/report/report.go
+++ b/reporter/v2/cmd/reporter/report/report.go
@@ -28,7 +28,7 @@ import (
 
 var log = logf.Log.WithName("reporter_report_cmd")
 
-var name, namespace, cafile, tokenFile, uploadTarget, localFilePath string
+var name, namespace, cafile, tokenFile, passwordFile, uploadTarget, localFilePath string
 var local, upload bool
 var retry int
 
@@ -61,6 +61,7 @@ var ReportCmd = &cobra.Command{
 			Retry:           ptr.Int(retry),
 			CaFile:          cafile,
 			TokenFile:       tokenFile,
+			PasswordFile:    passwordFile,
 			Local:           local,
 			Upload:          upload,
 			UploaderTarget:  uploadTarget,
@@ -93,6 +94,7 @@ func init() {
 	ReportCmd.Flags().StringVar(&namespace, "namespace", "", "namespace of the report")
 	ReportCmd.Flags().StringVar(&cafile, "cafile", "", "cafile for prometheus")
 	ReportCmd.Flags().StringVar(&tokenFile, "tokenfile", "", "token file for prometheus")
+	ReportCmd.Flags().StringVar(&passwordFile, "passwordfile", "", "password file for prometheus basicauth")
 	ReportCmd.Flags().StringVar(&uploadTarget, "uploadTarget", "redhat-insights", "target to upload to")
 	ReportCmd.Flags().StringVar(&localFilePath, "localFilePath", ".", "target to upload to")
 	ReportCmd.Flags().BoolVar(&local, "local", false, "run locally")

--- a/reporter/v2/pkg/reporter/config.go
+++ b/reporter/v2/pkg/reporter/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Retry           *int
 	CaFile          string
 	TokenFile       string
+	PasswordFile    string
 	Local           bool
 	Upload          bool
 	UploaderTarget

--- a/reporter/v2/pkg/reporter/task.go
+++ b/reporter/v2/pkg/reporter/task.go
@@ -179,10 +179,21 @@ func provideApiClient(
 		auth = fmt.Sprintf(string(content))
 	}
 
+	var userAuth *UserAuth
+	if config.PasswordFile != "" {
+		content, err := ioutil.ReadFile(config.PasswordFile)
+		if err != nil {
+			return nil, err
+		}
+		userAuth = &UserAuth{"internal", fmt.Sprintf(string(content))}
+
+	}
+
 	conf, err := NewSecureClient(&PrometheusSecureClientConfig{
 		Address:        fmt.Sprintf("https://%s.%s.svc:%v", name, namespace, port),
 		ServerCertFile: config.CaFile,
 		Token:          auth,
+		UserAuth:       userAuth,
 	})
 
 	if err != nil {

--- a/v2/assets/reporter/job.yaml
+++ b/v2/assets/reporter/job.yaml
@@ -21,25 +21,13 @@ spec:
               'report',
               '--cafile',
               '/etc/configmaps/operator-cert-ca-bundle/service-ca.crt',
-              '--tokenfile',
-              '/etc/auth-service-account/token',
             ]
           runAsUser:
           volumeMounts:
             - mountPath: /etc/configmaps/operator-cert-ca-bundle
               name: operator-certs-ca-bundle
               readOnly: true
-            - mountPath: /etc/auth-service-account
-              name: token-vol
-              readOnly: true
       volumes:
         - configMap:
             name: operator-certs-ca-bundle
           name: operator-certs-ca-bundle
-        - name: token-vol
-          projected:
-            sources:
-              - serviceAccountToken:
-                  audience: rhm-prometheus-meterbase.openshift-redhat-marketplace.svc
-                  expirationSeconds: 3600
-                  path: token


### PR DESCRIPTION
Use basicAuth and don't use TokenRequestProject until it is GA in kubeVersion 1.20.0+
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/