### PR TITLE
correct finalizer

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -1196,7 +1196,7 @@ func (r *MeterBaseReconciler) newPrometheusOperator(
 ) (*monitoringv1.Prometheus, error) {
 	prom, err := factory.NewPrometheusDeployment(cr, cfg)
 
-	factory.SetOwnerReference(prom, cr)
+	factory.SetOwnerReference(cr, prom)
 
 	if cr.Spec.Prometheus.Storage.Class == nil {
 		defaultClass, err := utils.GetDefaultStorageClass(r.Client)

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -977,7 +977,10 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 					rrs3Deployment,
 					func() (runtime.Object, error) {
 						dep := factory.NewRemoteResourceS3Deployment(instance)
-						factory.SetOwnerReference(dep, instance)
+						// Do not set an OwnerRef on the rrs3Dep
+						// A delete --cascade='foreground' will cause orphaned RRS3
+						// rrs3Dep will end up deleted before RRS3 child/parent finalizer cleanup
+						//factory.SetOwnerReference(instance, dep)
 						return dep, nil
 					},
 					args,
@@ -1006,7 +1009,7 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 					watchKeeperDeployment,
 					func() (runtime.Object, error) {
 						dep := factory.NewWatchKeeperDeployment(instance)
-						factory.SetOwnerReference(dep, instance)
+						factory.SetOwnerReference(instance, dep)
 						return dep, nil
 					},
 					args,
@@ -1322,21 +1325,21 @@ func (r *RazeeDeploymentReconciler) makeRazeeClusterMetaData(instance *marketpla
 			Name:      utils.RAZEE_CLUSTER_METADATA_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Labels: map[string]string{
-				"razee/cluster-metadata": "true",
-				"razee/watch-resource":   "lite",
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"razee/cluster-metadata":       "true",
+				"razee/watch-resource":         "lite",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 		},
 		Data: map[string]string{"name": instance.Spec.ClusterUUID},
 	}
-	r.factory.SetOwnerReference(cm, instance)
+	r.factory.SetOwnerReference(instance, cm)
 	return cm
 }
 
@@ -1349,19 +1352,19 @@ func (r *RazeeDeploymentReconciler) makeWatchKeeperNonNamespace(
 			Name:      utils.WATCH_KEEPER_NON_NAMESPACED_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 		Data: map[string]string{"v1_namespace": "true"},
 	}
-	r.factory.SetOwnerReference(cm, instance)
+	r.factory.SetOwnerReference(instance, cm)
 	return cm
 }
 
@@ -1374,18 +1377,18 @@ func (r *RazeeDeploymentReconciler) makeWatchKeeperLimitPoll(
 			Name:      utils.WATCH_KEEPER_LIMITPOLL_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 	}
-	r.factory.SetOwnerReference(cm, instance)
+	r.factory.SetOwnerReference(instance, cm)
 	return cm
 }
 
@@ -1396,19 +1399,19 @@ func (r *RazeeDeploymentReconciler) makeWatchKeeperConfig(instance *marketplacev
 			Name:      utils.WATCH_KEEPER_CONFIG_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 		Data: map[string]string{"RAZEEDASH_URL": instance.Spec.DeployConfig.RazeeDashUrl, "START_DELAY_MAX": "0"},
 	}
-	r.factory.SetOwnerReference(cm, instance)
+	r.factory.SetOwnerReference(instance, cm)
 	return cm
 }
 
@@ -1443,19 +1446,19 @@ func (r *RazeeDeploymentReconciler) makeWatchKeeperSecret(instance *marketplacev
 			Name:      utils.WATCH_KEEPER_SECRET_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 		Data: map[string][]byte{"RAZEEDASH_ORG_KEY": key},
 	}
-	r.factory.SetOwnerReference(&secret, instance)
+	r.factory.SetOwnerReference(instance, &secret)
 	return secret, err
 }
 
@@ -1469,20 +1472,20 @@ func (r *RazeeDeploymentReconciler) makeCOSReaderSecret(instance *marketplacev1a
 			Name:      utils.COS_READER_KEY_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 		Data: map[string][]byte{"accesskey": []byte(key)},
 	}
 
-	r.factory.SetOwnerReference(&secret, instance)
+	r.factory.SetOwnerReference(instance, &secret)
 	return secret, err
 }
 
@@ -1493,14 +1496,14 @@ func (r *RazeeDeploymentReconciler) makeParentRemoteResourceS3(instance *marketp
 			Name:      utils.PARENT_RRS3_RESOURCE_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 		},
 		Spec: marketplacev1alpha1.RemoteResourceS3Spec{

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -107,31 +107,31 @@ func (f *Factory) ReplaceImages(container *corev1.Container) {
 	}
 }
 
-func(f *Factory) addCertAnnotations(inAnnotations map[string]string)(map[string]string){
+func (f *Factory) addCertAnnotations(inAnnotations map[string]string) map[string]string {
 	certAnnotations := map[string]string{
-		"productID": "068a62892a1e4db39641342e592daa25",
+		"productID":     "068a62892a1e4db39641342e592daa25",
 		"productMetric": "FREE",
-		"productName": "IBM Cloud Platform Common Services",
+		"productName":   "IBM Cloud Platform Common Services",
 	}
 
-	for k,v := range certAnnotations{
+	for k, v := range certAnnotations {
 		inAnnotations[k] = v
 	}
 
 	return inAnnotations
 }
 
-func(f *Factory) addCertLabels(inLabels map[string]string)(map[string]string){
+func (f *Factory) addCertLabels(inLabels map[string]string) map[string]string {
 	certLabels := map[string]string{
-		"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+		"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 		"app.kubernetes.io/managed-by": "OLM",
-		"app.kubernetes.io/instance": "default",
+		"app.kubernetes.io/instance":   "default",
 	}
 
-	for k,v := range certLabels{
+	for k, v := range certLabels {
 		inLabels[k] = v
 	}
-	
+
 	return inLabels
 }
 
@@ -163,7 +163,7 @@ func (f *Factory) NewDeployment(manifest io.Reader) (*appsv1.Deployment, error) 
 	if d.Spec.Template.GetAnnotations() == nil {
 		d.Spec.Template.Annotations = make(map[string]string)
 	}
-	
+
 	d.Spec.Template.Annotations = f.addCertAnnotations(d.Spec.Template.Annotations)
 	d.Annotations = f.addCertAnnotations(d.Annotations)
 
@@ -196,7 +196,7 @@ func (f *Factory) NewService(manifest io.Reader) (*corev1.Service, error) {
 	}
 
 	d.Annotations = f.addCertAnnotations(d.Annotations)
-	
+
 	if d.GetLabels() == nil {
 		d.Labels = make(map[string]string)
 	}
@@ -221,7 +221,7 @@ func (f *Factory) NewConfigMap(manifest io.Reader) (*corev1.ConfigMap, error) {
 	}
 
 	d.Annotations = f.addCertAnnotations(d.Annotations)
-	
+
 	if d.GetLabels() == nil {
 		d.Labels = make(map[string]string)
 	}
@@ -246,7 +246,7 @@ func (f *Factory) NewSecret(manifest io.Reader) (*v1.Secret, error) {
 	}
 
 	s.Annotations = f.addCertAnnotations(s.Annotations)
-	
+
 	if s.GetLabels() == nil {
 		s.Labels = make(map[string]string)
 	}
@@ -271,7 +271,7 @@ func (f *Factory) NewJob(manifest io.Reader) (*batchv1.Job, error) {
 	}
 
 	j.Annotations = f.addCertAnnotations(j.Annotations)
-	
+
 	if j.GetLabels() == nil {
 		j.Labels = make(map[string]string)
 	}
@@ -298,7 +298,7 @@ func (f *Factory) NewPrometheus(
 	}
 
 	p.Annotations = f.addCertAnnotations(p.Annotations)
-	
+
 	if p.GetLabels() == nil {
 		p.Labels = make(map[string]string)
 	}
@@ -308,14 +308,14 @@ func (f *Factory) NewPrometheus(
 	if p.Spec.PodMetadata == nil {
 		p.Spec.PodMetadata = &monitoringv1.EmbeddedObjectMetadata{
 			Labels: map[string]string{
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 		}
 	}
@@ -742,15 +742,15 @@ func (f *Factory) NewWatchKeeperDeployment(instance *marketplacev1alpha1.RazeeDe
 			Name:      utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME,
 			Namespace: f.namespace,
 			Labels: map[string]string{
-				"razee/watch-resource": "lite",
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"razee/watch-resource":         "lite",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -771,17 +771,17 @@ func (f *Factory) NewWatchKeeperDeployment(instance *marketplacev1alpha1.RazeeDe
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                  utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME,
-						"razee/watch-resource": "lite",
-						"owned-by":             "marketplace.redhat.com-razee",
-						"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+						"app":                          utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME,
+						"razee/watch-resource":         "lite",
+						"owned-by":                     "marketplace.redhat.com-razee",
+						"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 						"app.kubernetes.io/managed-by": "OLM",
-						"app.kubernetes.io/instance": "default",
+						"app.kubernetes.io/instance":   "default",
 					},
 					Annotations: map[string]string{
-						"productID": "068a62892a1e4db39641342e592daa25",
+						"productID":     "068a62892a1e4db39641342e592daa25",
 						"productMetric": "FREE",
-						"productName": "IBM Cloud Platform Common Services",
+						"productName":   "IBM Cloud Platform Common Services",
 					},
 					Name: utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME,
 				},
@@ -896,12 +896,12 @@ func (f *Factory) NewWatchKeeperDeployment(instance *marketplacev1alpha1.RazeeDe
 
 type Owner metav1.Object
 
-func (f *Factory) SetOwnerReference(obj metav1.Object, owner Owner) error {
+func (f *Factory) SetOwnerReference(owner Owner, obj metav1.Object) error {
 	return controllerutil.SetOwnerReference(owner, obj, f.scheme)
 }
 
-func (f *Factory) SetControllerReference(obj metav1.Object, owner Owner) error {
-	return controllerutil.SetControllerReference(obj, owner, f.scheme)
+func (f *Factory) SetControllerReference(owner Owner, obj metav1.Object) error {
+	return controllerutil.SetControllerReference(owner, obj, f.scheme)
 }
 
 func (f *Factory) NewRemoteResourceS3Deployment(instance *marketplacev1alpha1.RazeeDeployment) *appsv1.Deployment {
@@ -920,15 +920,15 @@ func (f *Factory) NewRemoteResourceS3Deployment(instance *marketplacev1alpha1.Ra
 			Name:      utils.RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME,
 			Namespace: f.namespace,
 			Labels: map[string]string{
-				"razee/watch-resource": "lite",
-				"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+				"razee/watch-resource":         "lite",
+				"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 				"app.kubernetes.io/managed-by": "OLM",
-				"app.kubernetes.io/instance": "default",
+				"app.kubernetes.io/instance":   "default",
 			},
 			Annotations: map[string]string{
-				"productID": "068a62892a1e4db39641342e592daa25",
+				"productID":     "068a62892a1e4db39641342e592daa25",
 				"productMetric": "FREE",
-				"productName": "IBM Cloud Platform Common Services",
+				"productName":   "IBM Cloud Platform Common Services",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -949,17 +949,17 @@ func (f *Factory) NewRemoteResourceS3Deployment(instance *marketplacev1alpha1.Ra
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":                  utils.RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME,
-						"razee/watch-resource": "lite",
-						"owned-by":             "marketplace.redhat.com-razee",
-						"redhat.marketplace.com/name" : "redhat-marketplace-operator",
+						"app":                          utils.RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME,
+						"razee/watch-resource":         "lite",
+						"owned-by":                     "marketplace.redhat.com-razee",
+						"redhat.marketplace.com/name":  "redhat-marketplace-operator",
 						"app.kubernetes.io/managed-by": "OLM",
-						"app.kubernetes.io/instance": "default",
+						"app.kubernetes.io/instance":   "default",
 					},
 					Annotations: map[string]string{
-						"productID": "068a62892a1e4db39641342e592daa25",
+						"productID":     "068a62892a1e4db39641342e592daa25",
 						"productMetric": "FREE",
-						"productName": "IBM Cloud Platform Common Services",
+						"productName":   "IBM Cloud Platform Common Services",
 					},
 					Name: utils.RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME,
 				},

--- a/v2/pkg/utils/reconcileutils/finalizerAction.go
+++ b/v2/pkg/utils/reconcileutils/finalizerAction.go
@@ -63,8 +63,9 @@ func RunFinalizer(
 		accessor.SetFinalizers(utils.RemoveKey(accessor.GetFinalizers(), finalizer))
 
 		return Do(
-			Do(actions...),
-			UpdateAction(instance),
+			HandleResult(
+				Do(actions...),
+				OnNotFound(UpdateAction(instance))),
 		), nil
 	}
 }


### PR DESCRIPTION
Modify Factory Set(Owner/Controller)Reference to (owner, obj) to be consistent with controllerutil
  - Update uses of Set(Owner/Controller)Reference

Do not remove MarketplaceConfig finalizer until child objects are removed (by correcting finalizerAction)

Do not set an OwnerReference on RemoteResourceS3Deployment
  - If a foreground deletion is called (kubectl delete --cascade='foreground'), the RRS3 Deployment will be deleted before the finalizer can cleanup child/parent rrs3

