### PR TITLE
use CLUSTER_DISPLAY_NAME from rhm-pull-secret to set ClusterName on marketplace config

### DIFF
--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -167,7 +167,7 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 	}
 
 	var updateInstanceSpec bool 
-	if clusterDisplayName,ok := secret.Data[utils.ClusterDisplayName]; ok {
+	if clusterDisplayName,ok := secret.Data[utils.ClusterDisplayNameKey]; ok {
 		count := utf8.RuneCountInString(string(clusterDisplayName))
 		clusterName := strings.Trim(string(clusterDisplayName),"\n")
 

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -175,13 +175,12 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 			if count <= 256 {
 				marketplaceConfig.Spec.ClusterName = clusterName
 				updateInstanceSpec = true
-				reqLogger.Info("using CLUSTER_DISPLAY_NAME override","name", clusterName)
+				reqLogger.Info("setting ClusterName","name", clusterName)
 			} else {
 				err := errors.New("CLUSTER_DISPLAY_NAME exceeds 256 chars")
 				reqLogger.Error(err, "name",clusterDisplayName)
 			}
 		}
-		
 	} 
 
 	token := string(pullSecret)

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -254,7 +254,7 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 		err = r.Client.Update(context.TODO(), marketplaceConfig)
 
 		if err != nil {
-			reqLogger.Error(err, "Failed to create to update the marketplace config")
+			reqLogger.Error(err, "Failed to update the marketplace config")
 			return reconcile.Result{}, err
 		}
 	

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -78,6 +78,7 @@ const (
 	RHMPullSecretKey      = "PULL_SECRET"
 	RHMPullSecretStatus   = "marketplace.redhat.com/rhm-operator-secret-status"
 	RHMPullSecretMessage  = "marketplace.redhat.com/rhm-operator-secret-message"
+	ClusterDisplayName = "CLUSTER_DISPLAY_NAME"
 
 	RazeeWatchResource    = "razee/watch-resource"
 	RazeeWatchLevelLite   = "lite"

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -78,7 +78,7 @@ const (
 	RHMPullSecretKey      = "PULL_SECRET"
 	RHMPullSecretStatus   = "marketplace.redhat.com/rhm-operator-secret-status"
 	RHMPullSecretMessage  = "marketplace.redhat.com/rhm-operator-secret-message"
-	ClusterDisplayName = "CLUSTER_DISPLAY_NAME"
+	ClusterDisplayNameKey = "CLUSTER_DISPLAY_NAME"
 
 	RazeeWatchResource    = "razee/watch-resource"
 	RazeeWatchLevelLite   = "lite"


### PR DESCRIPTION
work for issue: [https://github.ibm.com/symposium/track-and-plan/issues/15303](url)

Checks for CLUSTER_DISPLAY_NAME field on rhm pull secret, if under 256 chars, updates marketplace config ClusterName. 