### PR TITLE
metering uptime and uwm fixes

### DIFF
--- a/v2/assets/metric-state/kube-state-metrics-service.yaml
+++ b/v2/assets/metric-state/kube-state-metrics-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  type: ExternalName
+  externalName: kube-state-metrics.openshift-monitoring.svc.cluster.local

--- a/v2/assets/metric-state/meterdefinition.yaml
+++ b/v2/assets/metric-state/meterdefinition.yaml
@@ -1,0 +1,20 @@
+apiVersion: marketplace.redhat.com/v1beta1
+kind: MeterDefinition
+metadata:
+  name: rhm-metric-state-uptime
+spec:
+  group: marketplace.redhat.com
+  kind: Pod
+  meters:
+  - aggregation: avg
+    metricId: rhm-metric-state-uptime
+    name: rhm-metric-state-uptime
+    period: 5m
+    query: avg_over_time(up{job="rhm-metric-state-service"}[5m])
+    workloadType: Pod
+  resourceFilters:
+  - label:
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: rhm-metric-state
+    workloadType: Pod

--- a/v2/assets/prometheus/meterdefinition.yaml
+++ b/v2/assets/prometheus/meterdefinition.yaml
@@ -1,0 +1,21 @@
+apiVersion: marketplace.redhat.com/v1beta1
+kind: MeterDefinition
+metadata:
+  name: rhm-prometheus-meterbase-uptime
+  namespace: openshift-redhat-marketplace
+spec:
+  group: marketplace.redhat.com
+  kind: Pod
+  meters:
+  - aggregation: avg
+    metricId: rhm-prometheus-meterbase-uptime
+    name: rhm-prometheus-meterbase-uptime
+    period: 5m
+    query: avg_over_time(up{job="rhm-prometheus-meterbase"}[5m])
+    workloadType: Pod
+  resourceFilters:
+  - label:
+      labelSelector:
+        matchLabels:
+          prometheus: rhm-marketplaceconfig-meterbase
+    workloadType: Pod

--- a/v2/assets/prometheus/service-monitor.yaml
+++ b/v2/assets/prometheus/service-monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rhm-prometheus-meterbase
+  labels:
+    marketplace.redhat.com/metering: "true"
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 2m
+    port: https
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: serving-certs-ca-bundle
+      cert: {}
+      serverName: rhm-prometheus-meterbase.openshift-redhat-marketplace.svc
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      app: prometheus
+      prometheus: rhm-marketplaceconfig-meterbase

--- a/v2/assets/prometheus/user-workload-monitoring-meterdefinition.yaml
+++ b/v2/assets/prometheus/user-workload-monitoring-meterdefinition.yaml
@@ -1,0 +1,22 @@
+apiVersion: marketplace.redhat.com/v1beta1
+kind: MeterDefinition
+metadata:
+  name: prometheus-user-workload-uptime
+  namespace: openshift-user-workload-monitoring
+spec:
+  group: marketplace.redhat.com
+  kind: Pod
+  meters:
+  - aggregation: avg
+    metricId: prometheus-user-workload-uptime
+    name: prometheus-user-workload-uptime
+    period: 5m
+    query: avg_over_time(up{job="prometheus-user-workload"}[5m])
+    workloadType: Pod
+  resourceFilters:
+  - label:
+      labelSelector:
+        matchLabels:
+          app: prometheus
+          prometheus: user-workload
+    workloadType: Pod

--- a/v2/assets/prometheus/user-workload-monitoring-service-monitor.yaml
+++ b/v2/assets/prometheus/user-workload-monitoring-service-monitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-user-workload
+  labels:
+    marketplace.redhat.com/metering: "true"
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 2m
+    port: metrics
+    scheme: https
+    scrapeTimeout: 2m
+    tlsConfig:
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: serving-certs-ca-bundle
+      cert: {}
+      serverName: prometheus-user-workload.openshift-user-workload-monitoring.svc
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      prometheus: user-workload

--- a/v2/assets/reporter/meterdefinition.yaml
+++ b/v2/assets/reporter/meterdefinition.yaml
@@ -1,0 +1,20 @@
+apiVersion: marketplace.redhat.com/v1beta1
+kind: MeterDefinition
+metadata:
+  name: rhm-meter-report-job-failed
+spec:
+  group: marketplace.redhat.com
+  kind: Service
+  meters:
+  - aggregation: sum
+    metricId: rhm-meter-report-job-failed
+    name: rhm-meter-report-job-failed
+    period: 5m
+    query: 'sum(kube_job_failed{job_name=~"meter-report-.*"}) without (condition)'
+    workloadType: Service
+  resourceFilters:
+  - label:
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: kube-state-metrics
+    workloadType: Service

--- a/v2/assets/reporter/user-workload-monitoring-job.yaml
+++ b/v2/assets/reporter/user-workload-monitoring-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rhm-meter-report
+  labels:
+    marketplace.redhat.com/report: 'true'
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    spec:
+      serviceAccount: redhat-marketplace-operator
+      restartPolicy: Never
+      containers:
+        - name: reporter
+          image: redhat-markplace-reporter
+          imagePullPolicy: Always
+          # additional args are added in factory
+          args:
+            [
+              'report',
+              '--cafile',
+              '/etc/configmaps/serving-certs-ca-bundle/service-ca.crt',
+              '--tokenfile',
+              '/etc/auth-service-account/token',
+            ]
+          runAsUser:
+          volumeMounts:
+            - mountPath: /etc/configmaps/serving-certs-ca-bundle
+              name: serving-certs-ca-bundle
+              readOnly: true
+            - mountPath: /etc/auth-service-account
+              name: token-vol
+              readOnly: true
+      volumes:
+        - configMap:
+            name: serving-certs-ca-bundle
+          name: serving-certs-ca-bundle
+        - name: token-vol
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3600
+                  path: token

--- a/v2/controllers/marketplace/meterreport_controller.go
+++ b/v2/controllers/marketplace/meterreport_controller.go
@@ -193,6 +193,10 @@ func (r *MeterReportReconciler) Reconcile(request reconcile.Request) (reconcile.
 				manifests.CreateIfNotExistsFactoryItem(
 					job,
 					func() (runtime.Object, error) {
+						if instance.Spec.PrometheusService.Name == utils.OPENSHIFT_MONITORING_THANOS_QUERIER_SERVICE_NAME &&
+							instance.Spec.PrometheusService.Namespace == utils.OPENSHIFT_MONITORING_NAMESPACE { // User Workload Monitoring
+							return r.factory.ReporterUserWorkloadMonitoringJob(instance, r.cfg.ReportController.RetryLimit)
+						}
 						return r.factory.ReporterJob(instance, r.cfg.ReportController.RetryLimit)
 					}, CreateWithAddController(instance),
 				),

--- a/v2/pkg/prometheus/thanos_api.go
+++ b/v2/pkg/prometheus/thanos_api.go
@@ -1,0 +1,92 @@
+// Copyright 2021 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"context"
+
+	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/common/log"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
+	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+/* ThanosQuerierAPI is used when userWorkloadMonitoring is enabled, and a query needs to be made through the
+Thanos Querier Service, which aggregates the Cluster & User metrics.
+However, it does not provide Prometheus Targets information, so there are cases where we only query the UWM service
+*/
+
+func queryForThanosQuerierService(
+	ctx context.Context,
+	cc ClientCommandRunner,
+) (*corev1.Service, error) {
+	service := &corev1.Service{}
+
+	name := types.NamespacedName{
+		Name:      utils.OPENSHIFT_MONITORING_THANOS_QUERIER_SERVICE_NAME,
+		Namespace: utils.OPENSHIFT_MONITORING_NAMESPACE,
+	}
+
+	if result, _ := cc.Do(ctx, GetAction(name, service)); !result.Is(Continue) {
+		return nil, errors.Wrap(result, "failed to get thanos querier service")
+	}
+
+	log.Info("retrieved thanos querier service")
+	return service, nil
+}
+
+func ProvideThanosQuerierAPI(
+	context context.Context,
+	cc ClientCommandRunner,
+	kubeInterface kubernetes.Interface,
+	deployedNamespace string,
+	reqLogger logr.Logger) (*PrometheusAPI, error) {
+
+	service, err := queryForThanosQuerierService(context, cc)
+	if err != nil {
+		return nil, err
+	}
+
+	certConfigMap, err := getCertConfigMap(context, cc, deployedNamespace, true)
+	if err != nil {
+		return nil, err
+	}
+
+	var saClient *ServiceAccountClient
+	var authToken string
+	saClient = NewServiceAccountClient(deployedNamespace, kubeInterface)
+
+	authToken, err = saClient.NewServiceAccountToken(utils.OPERATOR_SERVICE_ACCOUNT, "", 3600, reqLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	if certConfigMap != nil && authToken != "" && service != nil {
+		cert, err := parseCertificateFromConfigMap(*certConfigMap)
+		if err != nil {
+			return nil, err
+		}
+		prometheusAPI, err := NewThanosAPI(service, &cert, authToken)
+		if err != nil {
+			return nil, err
+		}
+		return prometheusAPI, nil
+	}
+	return nil, nil
+}

--- a/v2/pkg/prometheus/thanos_client.go
+++ b/v2/pkg/prometheus/thanos_client.go
@@ -1,0 +1,87 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"fmt"
+
+	"emperror.dev/errors"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/log"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func NewThanosAPI(
+	promService *corev1.Service,
+	caCert *[]byte,
+	token string,
+) (*PrometheusAPI, error) {
+	promAPI, err := provideThanosAPI(promService, caCert, token)
+	if err != nil {
+		return nil, err
+	}
+	prometheusAPI := &PrometheusAPI{promAPI}
+	return prometheusAPI, nil
+}
+
+func provideThanosAPI(
+	promService *corev1.Service,
+	caCert *[]byte,
+	token string,
+) (v1.API, error) {
+
+	var port int32
+	if promService == nil {
+		return nil, errors.New("Prometheus service not defined")
+	}
+
+	name := promService.Name
+	namespace := promService.Namespace
+
+	targetPort := intstr.FromString("web")
+
+	switch {
+	case targetPort.Type == intstr.Int:
+		port = targetPort.IntVal
+	default:
+		for _, p := range promService.Spec.Ports {
+			if p.Name == targetPort.StrVal {
+				port = p.Port
+			}
+		}
+	}
+
+	conf, err := NewSecureClientFromCert(&PrometheusSecureClientConfig{
+		Address: fmt.Sprintf("https://%s.%s.svc:%v", name, namespace, port),
+		Token:   token,
+		CaCert:  caCert,
+	})
+
+	if err != nil {
+		log.Error(err, "failed to setup NewSecureClient")
+		return nil, err
+	}
+
+	if conf == nil {
+		log.Error(err, "failed to setup NewSecureClient")
+		return nil, errors.New("client configuration is nil")
+	}
+
+	promAPI := v1.NewAPI(conf)
+	// p.promAPI = promAPI
+	return promAPI, nil
+}

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -51,6 +51,7 @@ const (
 	OPENSHIFT_USER_WORKLOAD_MONITORING_CONFIGMAP_NAME           = "user-workload-monitoring-config"
 	OPENSHIFT_USER_WORKLOAD_MONITORING_STATEFULSET_NAME         = "prometheus-user-workload"
 	OPENSHIFT_USER_WORKLOAD_MONITORING_SERVICE_NAME             = "prometheus-user-workload"
+	OPENSHIFT_MONITORING_THANOS_QUERIER_SERVICE_NAME            = "thanos-querier"
 	SERVING_CERTS_CA_BUNDLE_NAME                                = "serving-certs-ca-bundle"
 	KUBELET_SERVING_CA_BUNDLE_NAME                              = "kubelet-serving-ca-bundle"
 	OPENSHIFT_USER_WORKLOAD_MONITORING_OPERATOR_SERVICE_ACCOUNT = "prometheus-operator"


### PR DESCRIPTION
Add kube-state-metrics-service such that the MeterDefinition for rhm-meter-report-job-failed has a service match. Alternatively, the MeterDefinition could be created in the openshift-monitoring namespace.

Meterdefinitions to track uptime: rhm-metric-state-uptime, rhm-prometheus-meterbase-uptime, prometheus-user-workload-uptime

Servicemonitors to support tracking uptime: rhm-prometheus-meterbase, prometheus-user-workload

user-workload-monitoring-job.yaml is the Job run when using UWM, as the ca-bundle and audience is different

meterbase_controller
Add additional install/uninstall of servicemonitor, meterdefinition for self-monitoring
Use Thanos Querier service for UWM Query/QueryRange, which results in the merged cluster(kube-state) & user-workload(servicemonitors) metrics
Continue to query only user-workload-monitoring prom directly for Targets()

meterdefinition_controller
Use Thanos Querier service for UWM Query/QueryRange, which results in the merged cluster(kube-state) & user-workload(servicemonitors) metrics

meterreport_controller
Use the user-workload-monitoring-job.yaml for UWM meterreports

factory
add the new meterdefinitions, servicemonitors, job

query
Add a label_replace to remove exported_
metric-state labels collide with UWM multi-tenancy to where the metric-state labels get prefixed with exported_
https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md#multitenancy

thanos_api, thanos_client
modified from prometheus api,client with pointers to the appropriate service endpoint
