### PR TITLE
Disable razee features when an airgap environment is detected

### DIFF
--- a/metering/v2/go.sum
+++ b/metering/v2/go.sum
@@ -465,6 +465,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=

--- a/reporter/v2/go.sum
+++ b/reporter/v2/go.sum
@@ -450,6 +450,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=

--- a/tests/v2/go.mod
+++ b/tests/v2/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 // indirect
 	github.com/go-logr/logr v0.3.0
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/uuid v1.1.2

--- a/tests/v2/go.sum
+++ b/tests/v2/go.sum
@@ -454,6 +454,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=

--- a/v2/apis/marketplace/v1alpha1/marketplaceconfig_types.go
+++ b/v2/apis/marketplace/v1alpha1/marketplaceconfig_types.go
@@ -125,6 +125,8 @@ const (
 	// ConditionRegistered means the cluster registered.
 	ConditionRegistrationError status.ConditionType = "RegistationError"
 
+	ConditionIsAirGap status.ConditionType = "IsAirGap"
+
 	// Reasons for install
 	ReasonStartInstall          status.ConditionReason = "StartInstall"
 	ReasonRazeeInstalled        status.ConditionReason = "RazeeInstalled"

--- a/v2/controllers/marketplace/clusterregistration_controller.go
+++ b/v2/controllers/marketplace/clusterregistration_controller.go
@@ -118,25 +118,6 @@ func (r *ClusterRegistrationReconciler) Reconcile(request reconcile.Request) (re
 		return reconcile.Result{}, err
 	}
 
-	reqLogger.Info("account id found in token")
-	pullSecret, ok := rhmPullSecret.Data[utils.RHMPullSecretKey]
-
-	if !ok {
-		err := errors.New("rhm pull secret not found")
-		reqLogger.Error(err, "couldn't find pull secret")
-		return reconcile.Result{}, err
-	}
-
-	token := string(pullSecret)
-
-	mclient, err := marketplace.NewMarketplaceClientBuilder(r.cfg).
-		NewMarketplaceClient(token, tokenClaims)
-
-	if err != nil {
-		reqLogger.Error(err, "failed to build marketplaceclient")
-		return reconcile.Result{}, nil
-	}
-
 	newMarketplaceConfig := &marketplacev1alpha1.MarketplaceConfig{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
 		Namespace: request.Namespace,
@@ -147,101 +128,122 @@ func (r *ClusterRegistrationReconciler) Reconcile(request reconcile.Request) (re
 		newMarketplaceConfig = nil
 	}
 
-	if newMarketplaceConfig != nil {
-		reqLogger.Info("MarketPlace config object found, check status if its installed or not")
-		//Setting MarketplaceClientAccount
+	if !r.cfg.IsAirGap {
+		reqLogger.Info("account id found in token")
+		pullSecret, ok := rhmPullSecret.Data[utils.RHMPullSecretKey]
 
-		marketplaceClientAccount := &marketplace.MarketplaceClientAccount{
-			AccountId:   newMarketplaceConfig.Spec.RhmAccountID,
-			ClusterUuid: newMarketplaceConfig.Spec.ClusterUUID,
+		if !ok {
+			err := errors.New("rhm pull secret not found")
+			reqLogger.Error(err, "couldn't find pull secret")
+			return reconcile.Result{}, err
 		}
 
-		// Marketplace config object found
-		reqLogger.Info("Pulling MarketPlace config object status")
-		registrationStatusOutput, _ := mclient.RegistrationStatus(marketplaceClientAccount)
+		token := string(pullSecret)
 
-		if registrationStatusOutput.RegistrationStatus == marketplace.RegistrationStatusInstalled {
-			reqLogger.Info("MarketPlace config object is already registered for account")
+		mclient, err := marketplace.NewMarketplaceClientBuilder(r.cfg).
+			NewMarketplaceClient(token, tokenClaims)
 
-			//Update secret with status
-			if annotations[utils.RHMPullSecretStatus] != "success" {
-				reqLogger.Info("Updating secret with success status")
-				annotations[utils.RHMPullSecretStatus] = "success"
-				annotations[utils.RHMPullSecretMessage] = "rhm-operator-secret generated successfully"
-				rhmPullSecret.SetAnnotations(annotations)
-				if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
-					reqLogger.Error(err, "Failed to patch secret with Endpoint status")
-					return reconcile.Result{}, err
+		if err != nil {
+			reqLogger.Error(err, "failed to build marketplaceclient")
+			return reconcile.Result{}, nil
+		}
+		
+		if newMarketplaceConfig != nil {
+			reqLogger.Info("MarketPlace config object found, check status if its installed or not")
+			// Setting MarketplaceClientAccount
+
+			marketplaceClientAccount := &marketplace.MarketplaceClientAccount{
+				AccountId:   newMarketplaceConfig.Spec.RhmAccountID,
+				ClusterUuid: newMarketplaceConfig.Spec.ClusterUUID,
+			}
+
+			// Marketplace config object found
+			reqLogger.Info("Pulling MarketPlace config object status")
+			registrationStatusOutput, _ := mclient.RegistrationStatus(marketplaceClientAccount)
+
+			if registrationStatusOutput.RegistrationStatus == marketplace.RegistrationStatusInstalled {
+				reqLogger.Info("MarketPlace config object is already registered for account")
+
+				//Update secret with status
+				if annotations[utils.RHMPullSecretStatus] != "success" {
+					reqLogger.Info("Updating secret with success status")
+					annotations[utils.RHMPullSecretStatus] = "success"
+					annotations[utils.RHMPullSecretMessage] = "rhm-operator-secret generated successfully"
+					rhmPullSecret.SetAnnotations(annotations)
+					if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
+						reqLogger.Error(err, "Failed to patch secret with Endpoint status")
+						return reconcile.Result{}, err
+					}
+					reqLogger.Info("Secret updated with status on success")
 				}
-				reqLogger.Info("Secret updated with status on success")
 			}
 		}
-	}
 
-	reqLogger.Info("RHMarketPlace Pull Secret token found")
-	//Calling POST endpoint to pull the secret definition
-	newOptSecretObj, err := mclient.GetMarketplaceSecret()
-	if err != nil {
-		reqLogger.Info("RHMarketPlaceSecret failure")
-		reqLogger.Error(err, "RHMarketPlaceSecret failure")
-		annotations[utils.RHMPullSecretStatus] = "error"
-		annotations[utils.RHMPullSecretMessage] = err.Error()
-		rhmPullSecret.SetAnnotations(annotations)
-		if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
-			reqLogger.Error(err, "Failed to patch secret with Endpoint status")
-		}
-		return reconcile.Result{}, err
-	}
-	newOptSecretObj.SetNamespace(request.Namespace)
-
-	//Fetch the Secret with name redhat-Operator-secret
-	secretKeyname := types.NamespacedName{
-		Name:      newOptSecretObj.Name,
-		Namespace: newOptSecretObj.Namespace,
-	}
-
-	reqLogger.Info("retrieving secret", "name", secretKeyname.Name, "namespace", secretKeyname.Namespace)
-
-	optSecret := &v1.Secret{}
-	err = r.Client.Get(context.TODO(), secretKeyname, optSecret)
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			reqLogger.Error(err, "bad error getting secret")
-			return reconcile.Result{}, err
-		}
-
-		reqLogger.Info("secret not found, creating")
-		err = r.Client.Create(context.TODO(), newOptSecretObj)
+		reqLogger.Info("RHMarketPlace Pull Secret token found")
+		// Calling POST endpoint to pull the secret definition
+		newOptSecretObj, err := mclient.GetMarketplaceSecret()
 		if err != nil {
-			reqLogger.Error(err, "Failed to Create Secret Object")
+			reqLogger.Info("RHMarketPlaceSecret failure")
+			reqLogger.Error(err, "RHMarketPlaceSecret failure")
+			annotations[utils.RHMPullSecretStatus] = "error"
+			annotations[utils.RHMPullSecretMessage] = err.Error()
+			rhmPullSecret.SetAnnotations(annotations)
+			if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
+				reqLogger.Error(err, "Failed to patch secret with Endpoint status")
+			}
 			return reconcile.Result{}, err
 		}
-	} else {
-		reqLogger.Info("Comparing old and new rhm-operator-secret")
+		newOptSecretObj.SetNamespace(request.Namespace)
 
-		if !reflect.DeepEqual(newOptSecretObj.Data, optSecret.Data) {
-			reqLogger.Info("rhm-operator-secret are different copy")
-			optSecret.Data = newOptSecretObj.Data
+		// Fetch the Secret with name redhat-Operator-secret
+		secretKeyname := types.NamespacedName{
+			Name:      newOptSecretObj.Name,
+			Namespace: newOptSecretObj.Namespace,
+		}
 
-			err := r.Client.Update(context.TODO(), optSecret)
-			if err != nil {
-				reqLogger.Error(err, "could not update rhm-operator-secret with new object", "Resource", utils.RHMOperatorSecretName)
+		reqLogger.Info("retrieving secret", "name", secretKeyname.Name, "namespace", secretKeyname.Namespace)
+
+		optSecret := &v1.Secret{}
+		err = r.Client.Get(context.TODO(), secretKeyname, optSecret)
+		if err != nil {
+			if !k8serrors.IsNotFound(err) {
+				reqLogger.Error(err, "bad error getting secret")
 				return reconcile.Result{}, err
 			}
-		}
-	}
 
-	//Update secret with status
-	if annotations[utils.RHMPullSecretStatus] != "success" {
-		reqLogger.Info("Updating secret with success status")
-		annotations[utils.RHMPullSecretStatus] = "success"
-		annotations[utils.RHMPullSecretMessage] = "rhm-operator-secret generated successfully"
-		rhmPullSecret.SetAnnotations(annotations)
-		if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
-			reqLogger.Error(err, "Failed to patch secret with Endpoint status")
-			return reconcile.Result{}, err
+			reqLogger.Info("secret not found, creating")
+			err = r.Client.Create(context.TODO(), newOptSecretObj)
+			if err != nil {
+				reqLogger.Error(err, "Failed to Create Secret Object")
+				return reconcile.Result{}, err
+			}
+		} else {
+			reqLogger.Info("Comparing old and new rhm-operator-secret")
+
+			if !reflect.DeepEqual(newOptSecretObj.Data, optSecret.Data) {
+				reqLogger.Info("rhm-operator-secret are different copy")
+				optSecret.Data = newOptSecretObj.Data
+
+				err := r.Client.Update(context.TODO(), optSecret)
+				if err != nil {
+					reqLogger.Error(err, "could not update rhm-operator-secret with new object", "Resource", utils.RHMOperatorSecretName)
+					return reconcile.Result{}, err
+				}
+			}
 		}
-		reqLogger.Info("Secret updated with status on success")
+
+		//Update secret with status
+		if annotations[utils.RHMPullSecretStatus] != "success" {
+			reqLogger.Info("Updating secret with success status")
+			annotations[utils.RHMPullSecretStatus] = "success"
+			annotations[utils.RHMPullSecretMessage] = "rhm-operator-secret generated successfully"
+			rhmPullSecret.SetAnnotations(annotations)
+			if err := r.Client.Update(context.TODO(), &rhmPullSecret); err != nil {
+				reqLogger.Error(err, "Failed to patch secret with Endpoint status")
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("Secret updated with status on success")
+		}
 	}
 
 	//Create Markeplace Config object

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -389,7 +389,12 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 	foundRazee = &marketplacev1alpha1.RazeeDeployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: utils.RAZEE_NAME, Namespace: marketplaceConfig.Namespace}, foundRazee)
 	if err != nil && k8serrors.IsNotFound(err) {
+
 		newRazeeCrd := utils.BuildRazeeCr(marketplaceConfig.Namespace, marketplaceConfig.Spec.ClusterUUID, marketplaceConfig.Spec.DeploySecretName, marketplaceConfig.Spec.Features)
+
+		if r.cfg.IsAirGap {
+			newRazeeCrd.Spec.Features.Deployment = ptr.Bool(false)
+		}
 
 		// Sets the owner for foundRazee
 		if err = controllerutil.SetControllerReference(marketplaceConfig, newRazeeCrd, r.Scheme); err != nil {

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -329,6 +329,11 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 
 	var updateInstanceSpec bool
 
+	if r.cfg.IsAirGap {
+		marketplaceConfig.Spec.Features.Deployment = ptr.Bool(false)
+		marketplaceConfig.Spec.Features.Registration = ptr.Bool(false)
+	}
+
 	if secret != nil {
 		if clusterDisplayName, ok := secret.Data[utils.ClusterDisplayNameKey]; ok {
 			count := utf8.RuneCountInString(string(clusterDisplayName))
@@ -391,10 +396,6 @@ func (r *MarketplaceConfigReconciler) Reconcile(request reconcile.Request) (reco
 	if err != nil && k8serrors.IsNotFound(err) {
 
 		newRazeeCrd := utils.BuildRazeeCr(marketplaceConfig.Namespace, marketplaceConfig.Spec.ClusterUUID, marketplaceConfig.Spec.DeploySecretName, marketplaceConfig.Spec.Features)
-
-		if r.cfg.IsAirGap {
-			newRazeeCrd.Spec.Features.Deployment = ptr.Bool(false)
-		}
 
 		// Sets the owner for foundRazee
 		if err = controllerutil.SetControllerReference(marketplaceConfig, newRazeeCrd, r.Scheme); err != nil {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
 	github.com/go-logr/logr v0.3.0
 	github.com/go-logr/zapr v0.3.0 // indirect
 	github.com/golang/mock v1.4.4

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -450,6 +450,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db h1:gb2Z18BhTPJPpLQWj4T+rfKHYCHxRHCtRxhKKjRidVw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8 h1:a9ENSRDFBUPkJ5lCgVZh26+ZbGyoVJG7yb5SSzF5H54=

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -188,7 +188,6 @@ func setAirGapStatus(cfg *OperatorConfig)(error){
 		//TODO: do we need to return an error here if it's not "no such host found" ?
 	}
 
-	// fmt.Println("IP ------------- ",ip)
 	log.Info("found IP for redhat marketplace","ip",ip)
 	return nil
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -162,9 +162,6 @@ func ProvideInfrastructureAwareConfig(
 		}
 
 		cfg.IsAirGap = setAirGapStatus(cfg)
-		if err != nil {
-			return nil, errors.Wrap(err, "Could not get IP for redhat marketplace")
-		}
 
 		global = cfg
 	}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -161,7 +161,7 @@ func ProvideInfrastructureAwareConfig(
 
 		err = setAirGapStatus(cfg)
 		if err != nil {
-			return nil, errors.Wrap(err,"Could not get IP for redhat marketplace")
+			return nil, errors.Wrap(err, "Could not get IP for redhat marketplace")
 		}
 		global = cfg
 	}
@@ -169,9 +169,9 @@ func ProvideInfrastructureAwareConfig(
 	return global, nil
 }
 
-func setAirGapStatus(cfg *OperatorConfig)(error){
+func setAirGapStatus(cfg *OperatorConfig) error {
 	var rhmURL string
-	
+
 	rhmURL = utils.ProductionURL
 
 	if cfg.URL != "" {
@@ -185,47 +185,47 @@ func setAirGapStatus(cfg *OperatorConfig)(error){
 	}
 
 	var dialTimeoutFailed bool
-	u,_ := url.Parse(utils.ProductionURL)
+	u, _ := url.Parse(utils.ProductionURL)
 	trimmedProdUrl := u.Host
-	timeoutURL := fmt.Sprintf("%s:https",trimmedProdUrl)
+	timeoutURL := fmt.Sprintf("%s:https", trimmedProdUrl)
 	timeout := 1 * time.Second
-	_, err = net.DialTimeout("tcp",timeoutURL, timeout)
+	_, err = net.DialTimeout("tcp", timeoutURL, timeout)
 	if err != nil {
 		dialTimeoutFailed = checkError(err)
 	}
 
 	if ipLookUpFailed && dialTimeoutFailed {
-			cfg.IsAirGap = true
-			return nil
+		cfg.IsAirGap = true
+		return nil
 	}
 
-	log.Info("found IP for redhat marketplace","ip",ip)
+	log.Info("found IP for redhat marketplace", "ip", ip)
 	return nil
 }
 
-func checkError(err error)bool{
+func checkError(err error) bool {
 	if netError, ok := err.(net.Error); ok && netError.Timeout() {
-		log.Info("DialTimeout exceeds timeout","response",netError)
+		log.Info("DialTimeout exceeded timeout", "response", netError)
 		return true
 	}
 
-	switch t := err.(type) {	
+	switch t := err.(type) {
 	case *net.OpError:
 		if t.Op == "dial" {
-			log.Info("DialTimeout could not find host","response",t)
+			log.Info("DialTimeout could not find host", "response", t)
 			return true
-			
+
 		} else if t.Op == "read" {
-			log.Info("DialTimeout connection refused","response",t)
+			log.Info("DialTimeout connection refused", "response", t)
 			return true
 		}
 	case *net.DNSError:
-		if t.IsNotFound{
-			log.Info("LookupIP could not find host","response",t)
+		if t.IsNotFound {
+			log.Info("LookupIP could not find host", "response", t)
 			return true
 		}
 	}
-	
+
 	return false
 }
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -124,6 +124,8 @@ func ProvideConfig() (*OperatorConfig, error) {
 		if err != nil {
 			return nil, err
 		}
+		
+		cfg.IsAirGap = setAirGapStatus(&cfg)
 
 		cfg.Infrastructure = &Infrastructure{}
 		global = &cfg
@@ -159,17 +161,18 @@ func ProvideInfrastructureAwareConfig(
 			cfg.RelatedImages = RelatedImages(cfg.OSRelatedImages)
 		}
 
-		err = setAirGapStatus(cfg)
+		cfg.IsAirGap = setAirGapStatus(cfg)
 		if err != nil {
 			return nil, errors.Wrap(err, "Could not get IP for redhat marketplace")
 		}
+
 		global = cfg
 	}
 
 	return global, nil
 }
 
-func setAirGapStatus(cfg *OperatorConfig) error {
+func setAirGapStatus(cfg *OperatorConfig) (bool) {
 	var rhmURL string
 
 	rhmURL = utils.ProductionURL
@@ -195,12 +198,11 @@ func setAirGapStatus(cfg *OperatorConfig) error {
 	}
 
 	if ipLookUpFailed && dialTimeoutFailed {
-		cfg.IsAirGap = true
-		return nil
+		return true
 	}
 
 	log.Info("found IP for redhat marketplace", "ip", ip)
-	return nil
+	return false
 }
 
 func checkError(err error) bool {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -169,7 +169,7 @@ func ProvideInfrastructureAwareConfig(
 	return global, nil
 }
 
-func setAirGapStatus(cfg *OperatorConfig) (bool) {
+func setAirGapStatus(cfg *OperatorConfig) bool {
 	var rhmURL string
 
 	rhmURL = utils.ProductionURL

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Context("With AirGap environment information", func() {
+	Context("With AirGap environment status", func() {
 		var srv *mockdns.Server
 
 		BeforeEach(func() {

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Context("AirGap environment",func() {
+	Context("With AirGap environment information",func() {
 		BeforeEach(func(){
 			srv.Resolver().Zones[mockURL] = mockdns.Zone{A: []string{}}
 			srv.PatchNet(net.DefaultResolver)

--- a/v2/pkg/marketplace/marketplace_client.go
+++ b/v2/pkg/marketplace/marketplace_client.go
@@ -40,8 +40,8 @@ import (
 var logger = logf.Log.WithName("marketplace")
 
 const (
-	ProductionURL = "https://marketplace.redhat.com"
-	StageURL      = "https://sandbox.marketplace.redhat.com"
+	// ProductionURL = "https://marketplace.redhat.com"
+	// StageURL      = "https://sandbox.marketplace.redhat.com"
 )
 
 // endpoints
@@ -86,7 +86,7 @@ type MarketplaceClientBuilder struct {
 func NewMarketplaceClientBuilder(cfg *config.OperatorConfig) *MarketplaceClientBuilder {
 	builder := &MarketplaceClientBuilder{}
 
-	builder.Url = ProductionURL
+	builder.Url = utils.ProductionURL
 
 	if cfg.URL != "" {
 		builder.Url = cfg.URL
@@ -107,9 +107,9 @@ func (b *MarketplaceClientBuilder) NewMarketplaceClient(
 	marketplaceURL := b.Url
 
 	if tokenClaims != nil &&
-		b.Url == ProductionURL &&
+		b.Url == utils.ProductionURL &&
 		strings.ToLower(tokenClaims.Env) == strings.ToLower(EnvStage) {
-		marketplaceURL = StageURL
+		marketplaceURL = utils.StageURL
 		logger.V(2).Info("using stage for marketplace url", "url", marketplaceURL)
 	}
 

--- a/v2/pkg/marketplace/marketplace_client.go
+++ b/v2/pkg/marketplace/marketplace_client.go
@@ -39,11 +39,6 @@ import (
 
 var logger = logf.Log.WithName("marketplace")
 
-const (
-	// ProductionURL = "https://marketplace.redhat.com"
-	// StageURL      = "https://sandbox.marketplace.redhat.com"
-)
-
 // endpoints
 const (
 	PullSecretEndpoint   = "provisioning/v1/rhm-operator/rhm-operator-secret"

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -92,6 +92,9 @@ const (
 
 	/* Auth */
 	PrometheusAudience = "rhm-prometheus-meterbase.openshift-redhat-marketplace.svc"
+
+	ProductionURL = "https://marketplace.redhat.com"
+	StageURL      = "https://sandbox.marketplace.redhat.com"
 )
 
 var (

--- a/v2/tools/version/go.sum
+++ b/v2/tools/version/go.sum
@@ -386,6 +386,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
If the operator is running in an air-gapped it should not build the watchkeeper and remoteresources3 pods

**What's Changed:**
_config.go_
- Sets `IsAirGap` flag on the OperatorConfig if calls to net.DialTemout and net.LookupIp fail with appropriate errors

_marketplaceconfig_controller_
- If the `IsAirGap` flag is set, the marketplaceconfig controller sets feature flags on the marketplaceconfig cr:
```
marketplaceConfig.Spec.Features.Deployment = ptr.Bool(false)
marketplaceConfig.Spec.Features.Registration = ptr.Bool(false)
```
- marketplaceconfig controller then passes down the feature flags to the razee cr
- the `IsAirGap` flag is used to cut out code that calls the RHM backend

_clusterregistration_controller_
- the `IsAirGap` flag is used to cut out code that calls the RHM backend
