### PR TITLE
Feature/dataservice cronjob

### DIFF
--- a/airgap/v2/cmd/server/start/adminserver.go
+++ b/airgap/v2/cmd/server/start/adminserver.go
@@ -45,3 +45,19 @@ func (frs *AdminServerServer) CleanTombstones(ctx context.Context, in *adminserv
 	}
 	return res, nil
 }
+
+func (frs *AdminServerServer) DeleteFile(ctx context.Context, dfr *adminserver.DeleteFileRequest) (*adminserver.DeleteFileResponse, error) {
+
+	err := frs.B.FileStore.TombstoneFile(dfr.GetFileId())
+	if err != nil {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			fmt.Sprintf("Failed to mark file for deletion due to: %v", err),
+		)
+	}
+
+	res := &adminserver.DeleteFileResponse{
+		FileId: dfr.GetFileId(),
+	}
+	return res, nil
+}

--- a/reporter/v2/cmd/reporter/main.go
+++ b/reporter/v2/cmd/reporter/main.go
@@ -20,6 +20,7 @@ import (
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/cmd/reporter/report"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/cmd/reporter/upload"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -41,6 +42,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.AddCommand(report.ReportCmd)
+	rootCmd.AddCommand(upload.UploadCmd)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cobra.yaml)")
 }
 

--- a/reporter/v2/cmd/reporter/upload/upload.go
+++ b/reporter/v2/cmd/reporter/upload/upload.go
@@ -27,7 +27,8 @@ import (
 
 var log = logf.Log.WithName("reporter_upload_cmd")
 
-var cafile, tokenFile, deployedNamespace, dataServiceTokenFile, dataServiceCertFile string
+var deployedNamespace, dataServiceTokenFile, dataServiceCertFile string
+var uploadTargets []string
 var retry int
 
 var UploadCmd = &cobra.Command{
@@ -48,8 +49,6 @@ var UploadCmd = &cobra.Command{
 		cfg := &reporter.Config{
 			OutputDirectory:      tmpDir,
 			Retry:                ptr.Int(retry),
-			CaFile:               cafile,
-			TokenFile:            tokenFile,
 			DataServiceTokenFile: dataServiceTokenFile,
 			DataServiceCertFile:  dataServiceCertFile,
 			UploaderTarget:       uploadTarget,
@@ -78,10 +77,9 @@ var UploadCmd = &cobra.Command{
 }
 
 func init() {
-	UploadCmd.Flags().StringVar(&cafile, "cafile", "", "cafile for prometheus")
-	UploadCmd.Flags().StringVar(&tokenFile, "tokenfile", "", "token file for prometheus")
 	UploadCmd.Flags().StringVar(&dataServiceTokenFile, "dataServiceTokenFile", "", "token file for the data service")
 	UploadCmd.Flags().StringVar(&dataServiceCertFile, "dataServiceCertFile", "", "cert file for the data service")
+	UploadCmd.Flags().StringSliceVar(&uploadTargets, "uploadTargets", []string{"redhat-insights"}, "comma seperated list of targets to upload to")
 	UploadCmd.Flags().IntVar(&retry, "retry", 3, "number of retries")
 	UploadCmd.Flags().StringVar(&deployedNamespace, "deployedNamespace", "openshift-redhat-marketplace", "namespace where the rhm operator is deployed")
 }

--- a/reporter/v2/cmd/reporter/upload/upload.go
+++ b/reporter/v2/cmd/reporter/upload/upload.go
@@ -1,0 +1,87 @@
+// Copyright 2021 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/gotidy/ptr"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/pkg/reporter"
+	"github.com/spf13/cobra"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("reporter_upload_cmd")
+
+var cafile, tokenFile, deployedNamespace, dataServiceTokenFile, dataServiceCertFile string
+var retry int
+
+var UploadCmd = &cobra.Command{
+	Use:   "upload",
+	Short: "Upload the reports from dataservice to redhat-insights",
+	Long:  `Upload the reports from dataservice to redhat-insights`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log.Info("running the upload command")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		tmpDir := os.TempDir()
+
+		uploadTarget := reporter.MustParseUploaderTarget("redhat-insights")
+		log.Info("upload target", "target set to", uploadTarget.Name())
+
+		cfg := &reporter.Config{
+			OutputDirectory:      tmpDir,
+			Retry:                ptr.Int(retry),
+			CaFile:               cafile,
+			TokenFile:            tokenFile,
+			DataServiceTokenFile: dataServiceTokenFile,
+			DataServiceCertFile:  dataServiceCertFile,
+			UploaderTarget:       uploadTarget,
+			DeployedNamespace:    deployedNamespace,
+		}
+		cfg.SetDefaults()
+
+		uploadTask, err := reporter.NewUploadTask(
+			ctx,
+			cfg,
+		)
+
+		if err != nil {
+			log.Error(err, "couldn't initialize upload task")
+			os.Exit(1)
+		}
+
+		err = uploadTask.Upload()
+		if err != nil {
+			log.Error(err, "error running upload task")
+			os.Exit(1)
+		}
+
+		os.Exit(0)
+	},
+}
+
+func init() {
+	UploadCmd.Flags().StringVar(&cafile, "cafile", "", "cafile for prometheus")
+	UploadCmd.Flags().StringVar(&tokenFile, "tokenfile", "", "token file for prometheus")
+	UploadCmd.Flags().StringVar(&dataServiceTokenFile, "dataServiceTokenFile", "", "token file for the data service")
+	UploadCmd.Flags().StringVar(&dataServiceCertFile, "dataServiceCertFile", "", "cert file for the data service")
+	UploadCmd.Flags().IntVar(&retry, "retry", 3, "number of retries")
+	UploadCmd.Flags().StringVar(&deployedNamespace, "deployedNamespace", "openshift-redhat-marketplace", "namespace where the rhm operator is deployed")
+}

--- a/reporter/v2/pkg/reporter/admin.go
+++ b/reporter/v2/pkg/reporter/admin.go
@@ -1,0 +1,132 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/apis/adminserver"
+	v1 "github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/apis/model/v1"
+	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+)
+
+func (u *DataServiceAdmin) Name() string {
+	return "data-service"
+}
+
+type Admin interface {
+	DeleteFile(path string) error
+}
+
+type DataServiceAdmin struct {
+	DataServiceConfig
+	AdminServerClient adminserver.AdminServerClient
+}
+
+func NewDataServiceAdmin(dataServiceConfig *DataServiceConfig) (Admin, error) {
+	adminServerClient, err := createDataServiceAdminClient(dataServiceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("dac debug", "adminServerClient", adminServerClient)
+
+	return &DataServiceAdmin{
+		AdminServerClient: adminServerClient,
+		DataServiceConfig: *dataServiceConfig,
+	}, nil
+}
+
+func createDataServiceAdminClient(dataServiceConfig *DataServiceConfig) (adminserver.AdminServerClient, error) {
+
+	logger.Info("airgap url", "url", dataServiceConfig.Address)
+
+	options := []grpc.DialOption{}
+
+	/* creat tls */
+	tlsConf, err := createTlsConfig(dataServiceConfig.DataServiceCert)
+	if err != nil {
+		logger.Error(err, "failed to create creds")
+		return nil, err
+	}
+
+	options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+
+	/* create oauth2 token  */
+	oauth2Token := &oauth2.Token{
+		AccessToken: dataServiceConfig.DataServiceToken,
+	}
+
+	perRPC := oauth.NewOauthAccess(oauth2Token)
+	options = append(options, grpc.WithPerRPCCredentials(perRPC))
+
+	conn, err := grpc.Dial(dataServiceConfig.Address, options...)
+	if err != nil {
+		logger.Error(err, "failed to establish connection")
+		return nil, err
+	}
+
+	client := adminserver.NewAdminServerClient(conn)
+
+	return client, nil
+}
+
+func (d *DataServiceAdmin) DeleteFile(path string) error {
+	fn := strings.TrimSpace(path)
+	var req *adminserver.DeleteFileRequest
+
+	// Validate input and prepare request
+	if len(fn) == 0 {
+		return fmt.Errorf("file id/name is blank")
+	} else {
+		req = &adminserver.DeleteFileRequest{
+			FileId: &v1.FileID{
+				Data: &v1.FileID_Name{
+					Name: fn},
+			},
+		}
+	}
+
+	_, err := d.AdminServerClient.DeleteFile(context.Background(), req)
+	if err != nil {
+		return fmt.Errorf("failed to attempt delete due to: %v", err)
+	}
+
+	return nil
+}
+
+func ProvideAdmin(
+	ctx context.Context,
+	cc ClientCommandRunner,
+	log logr.Logger,
+	reporterConfig *Config,
+) (Admin, error) {
+
+	dataServiceConfig, err := provideDataServiceConfig(reporterConfig.DeployedNamespace, reporterConfig.DataServiceTokenFile, reporterConfig.DataServiceCertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDataServiceAdmin(dataServiceConfig)
+
+}

--- a/reporter/v2/pkg/reporter/admin.go
+++ b/reporter/v2/pkg/reporter/admin.go
@@ -49,8 +49,6 @@ func NewDataServiceAdmin(dataServiceConfig *DataServiceConfig) (Admin, error) {
 		return nil, err
 	}
 
-	logger.Info("dac debug", "adminServerClient", adminServerClient)
-
 	return &DataServiceAdmin{
 		AdminServerClient: adminServerClient,
 		DataServiceConfig: *dataServiceConfig,
@@ -63,7 +61,7 @@ func createDataServiceAdminClient(dataServiceConfig *DataServiceConfig) (adminse
 
 	options := []grpc.DialOption{}
 
-	/* creat tls */
+	/* create tls */
 	tlsConf, err := createTlsConfig(dataServiceConfig.DataServiceCert)
 	if err != nil {
 		logger.Error(err, "failed to create creds")

--- a/reporter/v2/pkg/reporter/downloader.go
+++ b/reporter/v2/pkg/reporter/downloader.go
@@ -1,0 +1,183 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/apis/fileretreiver"
+	v1 "github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/apis/model/v1"
+	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+)
+
+func (u *DataServiceDownloader) Name() string {
+	return "data-service"
+}
+
+type Downloader interface {
+	DownloadFile(path string) ([]byte, error)
+	ListFiles() ([]string, error)
+}
+
+type DataServiceDownloader struct {
+	DataServiceConfig
+	FileRetreiverClient fileretreiver.FileRetreiverClient
+}
+
+func NewDataServiceDownloader(dataServiceConfig *DataServiceConfig) (Downloader, error) {
+	fileRetreiverClient, err := createDataServiceDownloadClient(dataServiceConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DataServiceDownloader{
+		FileRetreiverClient: fileRetreiverClient,
+		DataServiceConfig:   *dataServiceConfig,
+	}, nil
+}
+
+func createDataServiceDownloadClient(dataServiceConfig *DataServiceConfig) (fileretreiver.FileRetreiverClient, error) {
+
+	logger.Info("airgap url", "url", dataServiceConfig.Address)
+
+	options := []grpc.DialOption{}
+
+	/* creat tls */
+	tlsConf, err := createTlsConfig(dataServiceConfig.DataServiceCert)
+	if err != nil {
+		logger.Error(err, "failed to create creds")
+		return nil, err
+	}
+
+	options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(tlsConf)))
+
+	/* create oauth2 token  */
+	oauth2Token := &oauth2.Token{
+		AccessToken: dataServiceConfig.DataServiceToken,
+	}
+
+	perRPC := oauth.NewOauthAccess(oauth2Token)
+	options = append(options, grpc.WithPerRPCCredentials(perRPC))
+
+	conn, err := grpc.Dial(dataServiceConfig.Address, options...)
+	if err != nil {
+		logger.Error(err, "failed to establish connection")
+		return nil, err
+	}
+
+	client := fileretreiver.NewFileRetreiverClient(conn)
+
+	return client, nil
+}
+
+func (d *DataServiceDownloader) ListFiles() ([]string, error) {
+	var req *fileretreiver.ListFileMetadataRequest
+
+	logger.Info("starting to list files")
+
+	fileList := []string{}
+
+	req = &fileretreiver.ListFileMetadataRequest{
+		IncludeDeletedFiles: false,
+	}
+
+	resultStream, err := d.FileRetreiverClient.ListFileMetadata(context.Background(), req)
+	if err != nil {
+		return fileList, fmt.Errorf("error while opening stream: %v", err)
+	}
+
+	for {
+		response, err := resultStream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return fileList, fmt.Errorf("error while reading stream: %v", err)
+		}
+
+		fileList = append(fileList, response.GetResults().FileId.GetName())
+	}
+
+	logger.Info("dac debug", "listFileMetadataResponse.Results", fileList)
+
+	return fileList, nil
+
+}
+
+func (d *DataServiceDownloader) DownloadFile(path string) ([]byte, error) {
+	fn := strings.TrimSpace(path)
+	var req *fileretreiver.DownloadFileRequest
+
+	// Validate input and prepare request
+	if len(fn) == 0 {
+		return nil, fmt.Errorf("file id/name is blank")
+	} else {
+		req = &fileretreiver.DownloadFileRequest{
+			FileId: &v1.FileID{
+				Data: &v1.FileID_Name{
+					Name: fn},
+			},
+			DeleteOnDownload: false,
+		}
+	}
+
+	resultStream, err := d.FileRetreiverClient.DownloadFile(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to attempt download due to: %v", err)
+	}
+
+	var bs []byte
+	for {
+		file, err := resultStream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("error while reading stream: %v", err)
+		}
+
+		data := file.GetChunkData()
+		if bs == nil {
+			bs = data
+		} else {
+			bs = append(bs, data...)
+		}
+	}
+
+	return bs, nil
+}
+
+func ProvideDownloader(
+	ctx context.Context,
+	cc ClientCommandRunner,
+	log logr.Logger,
+	reporterConfig *Config,
+) (Downloader, error) {
+
+	dataServiceConfig, err := provideDataServiceConfig(reporterConfig.DeployedNamespace, reporterConfig.DataServiceTokenFile, reporterConfig.DataServiceCertFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDataServiceDownloader(dataServiceConfig)
+
+}

--- a/reporter/v2/pkg/reporter/upload_task.go
+++ b/reporter/v2/pkg/reporter/upload_task.go
@@ -1,0 +1,69 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reporter
+
+import (
+	"context"
+
+	rhmclient "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/client"
+	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type UploadTask struct {
+	CC        ClientCommandRunner
+	K8SClient rhmclient.SimpleClient
+	Ctx       context.Context
+	Config    *Config
+	K8SScheme *runtime.Scheme
+	Downloader
+	Admin
+}
+
+func (r *UploadTask) Upload() error {
+	logger.Info("upload task run start")
+
+	// List the files from DataService
+	fileList, err := r.Downloader.ListFiles()
+	if err != nil {
+		return err
+	}
+
+	for _, file := range fileList {
+		// Download the file from DataService
+		logger.Info("dac debug", "Download File", file)
+
+		fileBytes, err := r.Downloader.DownloadFile(file)
+		if err != nil {
+			return err
+		}
+		logger.Info("dac debug", "Downloaded File", file)
+
+		// Upload the file to Insights
+
+		// Mark the file as deleted in DataService
+		logger.Info("dac debug", "Deleting File", file)
+		err = r.Admin.DeleteFile(file)
+		if err != nil {
+			return err
+		}
+		logger.Info("dac debug", "Deleted File", file)
+
+		logger.Info("dac debug", "fileBytes", fileBytes)
+
+	}
+
+	return nil
+}

--- a/reporter/v2/pkg/reporter/wire.go
+++ b/reporter/v2/pkg/reporter/wire.go
@@ -61,3 +61,19 @@ func NewReporter(
 		wire.Bind(new(client.Client), new(rhmclient.SimpleClient)),
 	))
 }
+
+func NewUploadTask(
+	ctx context.Context,
+	config *Config,
+) (*UploadTask, error) {
+	panic(wire.Build(
+		reconcileutils.CommandRunnerProviderSet,
+		managers.ProvideSimpleClientSet,
+		wire.Struct(new(UploadTask), "*"),
+		wire.InterfaceValue(new(logr.Logger), logger),
+		ProvideDownloader,
+		ProvideAdmin,
+		provideScheme,
+		wire.Bind(new(client.Client), new(rhmclient.SimpleClient)),
+	))
+}

--- a/reporter/v2/pkg/reporter/wire.go
+++ b/reporter/v2/pkg/reporter/wire.go
@@ -72,6 +72,7 @@ func NewUploadTask(
 		wire.Struct(new(UploadTask), "*"),
 		wire.InterfaceValue(new(logr.Logger), logger),
 		ProvideDownloader,
+		ProvideUploader,
 		ProvideAdmin,
 		provideScheme,
 		wire.Bind(new(client.Client), new(rhmclient.SimpleClient)),

--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -86,3 +86,43 @@ func NewReporter(task *Task) (*MarketplaceReporter, error) {
 var (
 	_wireLogrLoggerValue = logger
 )
+
+func NewUploadTask(ctx context.Context, config2 *Config) (*UploadTask, error) {
+	restConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	restMapper, err := managers.NewDynamicRESTMapper(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	scheme := provideScheme()
+	simpleClient, err := managers.ProvideSimpleClient(restConfig, restMapper, scheme)
+	if err != nil {
+		return nil, err
+	}
+	logrLogger := _wireLoggerValue2
+	clientCommandRunner := reconcileutils.NewClientCommand(simpleClient, scheme, logrLogger)
+	downloader, err := ProvideDownloader(ctx, clientCommandRunner, logrLogger, config2)
+	if err != nil {
+		return nil, err
+	}
+	admin, err := ProvideAdmin(ctx, clientCommandRunner, logrLogger, config2)
+	if err != nil {
+		return nil, err
+	}
+	uploadTask := &UploadTask{
+		CC:         clientCommandRunner,
+		K8SClient:  simpleClient,
+		Ctx:        ctx,
+		Config:     config2,
+		K8SScheme:  scheme,
+		Downloader: downloader,
+		Admin:      admin,
+	}
+	return uploadTask, nil
+}
+
+var (
+	_wireLoggerValue2 = logger
+)

--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -107,6 +107,10 @@ func NewUploadTask(ctx context.Context, config2 *Config) (*UploadTask, error) {
 	if err != nil {
 		return nil, err
 	}
+	uploader, err := ProvideUploader(ctx, clientCommandRunner, logrLogger, config2)
+	if err != nil {
+		return nil, err
+	}
 	admin, err := ProvideAdmin(ctx, clientCommandRunner, logrLogger, config2)
 	if err != nil {
 		return nil, err
@@ -118,6 +122,7 @@ func NewUploadTask(ctx context.Context, config2 *Config) (*UploadTask, error) {
 		Config:     config2,
 		K8SScheme:  scheme,
 		Downloader: downloader,
+		Uploader:   uploader,
 		Admin:      admin,
 	}
 	return uploadTask, nil

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -1,9 +1,8 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: rhm-meter-report
+  name: rhm-meter-report-upload
 spec:
-  schedule: "*/5 * * * *"
   jobTemplate:
     spec:
       template:
@@ -18,10 +17,6 @@ spec:
               args:
                 [
                   'upload',
-                  '--cafile',
-                  '/etc/configmaps/operator-cert-ca-bundle/service-ca.crt',
-                  '--tokenfile',
-                  '/etc/auth-service-account/token',
                 ]
               runAsUser:
               volumeMounts:

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rhm-meter-report
+spec:
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccount: redhat-marketplace-operator
+          restartPolicy: Never
+          containers:
+            - name: reporter
+              image: redhat-markplace-reporter
+              imagePullPolicy: Always
+              # additional args are added in factory
+              args:
+                [
+                  'upload',
+                  '--cafile',
+                  '/etc/configmaps/operator-cert-ca-bundle/service-ca.crt',
+                  '--tokenfile',
+                  '/etc/auth-service-account/token',
+                ]
+              runAsUser:
+              volumeMounts:
+                - mountPath: /etc/configmaps/operator-cert-ca-bundle
+                  name: operator-certs-ca-bundle
+                  readOnly: true
+                - mountPath: /etc/auth-service-account
+                  name: token-vol
+                  readOnly: true
+          volumes:
+            - configMap:
+                name: operator-certs-ca-bundle
+              name: operator-certs-ca-bundle
+            - name: token-vol
+              projected:
+                sources:
+                  - serviceAccountToken:
+                      audience: rhm-prometheus-meterbase.openshift-redhat-marketplace.svc
+                      expirationSeconds: 3600
+                      path: token

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -70,6 +70,7 @@ rules:
       - extensions
     resources:
       - jobs
+      - cronjobs
     verbs:
       - get
       - list
@@ -609,6 +610,7 @@ rules:
       - extensions
     resources:
       - jobs
+      - cronjobs
     verbs:
       - get
       - list

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -23,7 +23,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	mathrand "math/rand"
 	"strings"
+	"time"
 
 	"github.com/gotidy/ptr"
 	routev1 "github.com/openshift/api/route/v1"
@@ -687,6 +689,12 @@ func (f *Factory) UpdateReporterCronJob(
 
 	if j.GetNamespace() == "" {
 		j.SetNamespace(f.namespace)
+	}
+
+	mathrand.Seed(time.Now().UnixNano())
+
+	if j.Spec.Schedule == "" {
+		j.Spec.Schedule = fmt.Sprintf("%v * * * *", mathrand.Intn(59))
 	}
 
 	j.Spec.JobTemplate.Spec.BackoffLimit = backoffLimit


### PR DESCRIPTION
If meterbase.dataServiceEnabled = true
  enable the creation of the rhm-meter-report-upload hourly CronJob

CronJob runs new reporter "uploadCmd"
- List the Files, for each
	- Download the file from data-service
	- Upload the file to redhat-insights
	- Delete the file from data-service


Known issues

When meterreports are wiped and recreated in batch, it hits a concurrency error on data-service and fails the Job
Error getting response  {"error": "rpc error: code = Unknown desc = Failed to save file in database: database is locked"}

When meterreports are wiped and recreated in batch, before the data-service is ready
Error getting response  {"error": "rpc error: code = Unknown desc = Failed to save file in database: call exec-sql (budget 0s): receive: header: EOF"}

The Job tends to get rerun and succeed within the 5 retry limit