### PR TITLE
bugfix: Configurable Resources

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"bytes"
+	"reflect"
 	"sync"
 	"time"
 
@@ -22,6 +24,8 @@ import (
 	"github.com/caarlos0/env/v6"
 	rhmclient "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/client"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -43,6 +47,21 @@ type OperatorConfig struct {
 	*Infrastructure
 	OLMInformation
 	MeterBaseValues
+	Config EnvConfig `env:"CONFIG"`
+}
+
+// ENVCONFIG is a map of containerName to a corev1 resource requirements
+// intended to set children
+type EnvConfig struct {
+	Features         *Features               `json:"features,omitempty"`
+	Controller       *ControllerValues       `json:"controller,omitempty"`
+	ReportController *ReportControllerConfig `json:"reportController,omitempty"`
+	MeterController  *MeterBaseValues        `json:"meterController,omitempty"`
+	Resources        *Resources              `json:"resources,omitempty"`
+}
+
+type Resources struct {
+	Containers map[string]corev1.ResourceRequirements `json:"containers"`
 }
 
 // RelatedImages stores relatedimages for the operator
@@ -77,28 +96,28 @@ type OSRelatedImages struct {
 
 // Features store feature flags
 type Features struct {
-	IBMCatalog bool `env:"FEATURE_IBMCATALOG" envDefault:"true"`
+	IBMCatalog bool `env:"FEATURE_IBMCATALOG" envDefault:"true" json:"IBMCatalog"`
 }
 
 // Marketplace configuration
 type Marketplace struct {
-	URL            string `env:"MARKETPLACE_URL" envDefault:""`
-	InsecureClient bool   `env:"MARKETPLACE_HTTP_INSECURE_MODE" envDefault:"false"`
+	URL            string `env:"MARKETPLACE_URL" envDefault:"" json:"url"`
+	InsecureClient bool   `env:"MARKETPLACE_HTTP_INSECURE_MODE" envDefault:"false" json:"insecureClient"`
 }
 
 type ControllerValues struct {
-	DeploymentNamespace           string        `env:"POD_NAMESPACE" envDefault:"openshift-redhat-marketplace"`
-	MeterDefControllerRequeueRate time.Duration `env:"METER_DEF_CONTROLLER_REQUEUE_RATE" envDefault:"1h"`
+	DeploymentNamespace           string        `env:"POD_NAMESPACE" envDefault:"openshift-redhat-marketplace" json:"deploymentNamespace"`
+	MeterDefControllerRequeueRate time.Duration `env:"METER_DEF_CONTROLLER_REQUEUE_RATE" envDefault:"1h" json:"meterDefControllerRequeueRate"`
 }
 
 type MeterBaseValues struct {
-	TransitionTime time.Duration `env:"METERBASE_TRANSITION_TIME" envDefault:"24h"`
+	TransitionTime time.Duration `env:"METERBASE_TRANSITION_TIME" envDefault:"24h" json:"transitionTime"`
 }
 
 // ReportConfig stores some changeable information for creating a report
 type ReportControllerConfig struct {
-	RetryTime  time.Duration `env:"REPORT_RETRY_TIME_DURATION" envDefault:"6h"`
-	RetryLimit *int32        `env:"REPORT_RETRY_LIMIT"`
+	RetryTime  time.Duration `env:"REPORT_RETRY_TIME_DURATION" envDefault:"6h" json:"retryTime"`
+	RetryLimit *int32        `env:"REPORT_RETRY_LIMIT" json:"retryLimit,omitempty"`
 }
 
 type OLMInformation struct {
@@ -114,6 +133,17 @@ func reset() {
 	global = nil
 }
 
+var customUnmarshalers = map[reflect.Type]env.ParserFunc{
+	reflect.TypeOf(EnvConfig{}): func(text string) (interface{}, error) {
+		envConfig := EnvConfig{}
+		err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(text)), 100).Decode(&envConfig)
+		if err != nil {
+			return nil, err
+		}
+		return envConfig, nil
+	},
+}
+
 // ProvideConfig gets the config from env vars
 func ProvideConfig() (*OperatorConfig, error) {
 	globalMutex.Lock()
@@ -121,7 +151,7 @@ func ProvideConfig() (*OperatorConfig, error) {
 
 	if global == nil {
 		cfg := OperatorConfig{}
-		err := env.Parse(&cfg)
+		err := env.ParseWithFuncs(&cfg, customUnmarshalers)
 		if err != nil {
 			return nil, err
 		}
@@ -151,7 +181,7 @@ func ProvideInfrastructureAwareConfig(
 
 		cfg.Infrastructure = inf
 
-		err = env.Parse(cfg)
+		err = env.ParseWithFuncs(cfg, customUnmarshalers)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse config")
 		}


### PR DESCRIPTION
- Adds a env flag called `CONFIG` where you can set container resources
- Adds function to factory to match containers by name and override container resources based on the `CONFIG` configuration.

For example, setting a config env flag on the subscription override the limits for "system" and "system2" container names.
```
CONFIG: {"resources":{"containers":{"system":{"limits":{"cpu":"500m"}},"system2":{"limits":{"cpu":"1"}}}}}
```