### PR TITLE
send events for disabled insights

### DIFF
--- a/reporter/v2/cmd/reporter/reconciler/reconcile.go
+++ b/reporter/v2/cmd/reporter/reconciler/reconcile.go
@@ -16,13 +16,19 @@ package reconciler
 
 import (
 	"context"
-	"errors"
 	"os"
 	"time"
+
+	"emperror.dev/errors"
 
 	"github.com/gotidy/ptr"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/pkg/reporter"
 	"github.com/spf13/cobra"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -81,6 +87,15 @@ var ReconcileCmd = &cobra.Command{
 		}
 		cfg.SetDefaults()
 
+		recorder, err := reporter.NewEventRecorder(ctx, cfg)
+		if err != nil {
+			log.Error(err, "couldn't initialize event recorder")
+			os.
+				Exit(1)
+		}
+
+		job := getJob()
+
 		task, err := reporter.NewReconcileTask(
 			ctx,
 			cfg,
@@ -88,12 +103,25 @@ var ReconcileCmd = &cobra.Command{
 		)
 
 		if err != nil {
+			var comp *reporter.ReportJobError
+
+			if errors.As(err, &comp) {
+				log.Error(err, "report job error")
+				recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
+			}
 			log.Error(err, "couldn't initialize task")
 			os.Exit(1)
 		}
 
 		err = task.Run(ctx)
 		if err != nil {
+			var comp *reporter.ReportJobError
+
+			if errors.As(err, &comp) {
+				log.Error(err, "report job error")
+				recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
+			}
+
 			log.Error(err, "error running task")
 			os.Exit(1)
 		}
@@ -123,4 +151,22 @@ func init() {
 	ReconcileCmd.Flags().StringVar(&prometheusPort, "prometheus-port", "rbac", "cert file for the data service")
 
 	ReconcileCmd.Flags().StringVar(&reporterSchema, "reporterSchema", "v1alpha1", "reporter version schema to write")
+}
+
+func getJob() *batchv1.Job {
+
+	cl, err := client.New(config.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		log.Error(err, "failed to create client")
+		os.Exit(1)
+	}
+
+	job := &batchv1.Job{}
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: os.Getenv("JOB_NAME"), Namespace: os.Getenv("POD_NAMESPACE")}, job)
+	if err != nil {
+		log.Error(err, "could not get running job")
+		os.Exit(1)
+	}
+
+	return job
 }

--- a/reporter/v2/cmd/reporter/reconciler/reconcile.go
+++ b/reporter/v2/cmd/reporter/reconciler/reconcile.go
@@ -85,6 +85,7 @@ var ReconcileCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "couldn't initialize event broadcaster")
 		}
+		defer stopBroadcast()
 
 		task, err := reporter.NewReconcileTask(
 			ctx,
@@ -92,7 +93,6 @@ var ReconcileCmd = &cobra.Command{
 			broadcaster,
 			reporter.Namespace(namespace),
 		)
-		defer stopBroadcast()
 
 		if err != nil {
 			return errors.Wrap(err, "couldn't initialize task")

--- a/reporter/v2/cmd/reporter/reconciler/reconcile.go
+++ b/reporter/v2/cmd/reporter/reconciler/reconcile.go
@@ -87,7 +87,6 @@ var ReconcileCmd = &cobra.Command{
 			log.Error(err, "couldn't initialize event broadcaster")
 			os.Exit(1)
 		}
-		//defer stopBroadcast()
 
 		task, err := reporter.NewReconcileTask(
 			ctx,

--- a/reporter/v2/cmd/reporter/report/report.go
+++ b/reporter/v2/cmd/reporter/report/report.go
@@ -22,8 +22,10 @@ import (
 	"emperror.dev/errors"
 	"github.com/gotidy/ptr"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/pkg/reporter"
-	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	"github.com/spf13/cobra"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -94,13 +96,18 @@ var ReportCmd = &cobra.Command{
 			cfg,
 		)
 
-		report := &marketplacev1alpha1.MeterReport{}
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      os.Getenv("POD_NAME"),
+				Namespace: os.Getenv("POD_NAMESPACE"),
+			},
+		}
 
 		if err != nil {
 			var comp *reporter.ReportJobError
 			if errors.As(err, &comp) {
 				log.Error(err, "report job error")
-				recorder.Event(report, "Warning", "ReportJobError", "No insights")
+				recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
 			}
 			log.Error(err, "couldn't initialize task")
 			os.Exit(1)

--- a/reporter/v2/cmd/reporter/report/report.go
+++ b/reporter/v2/cmd/reporter/report/report.go
@@ -23,9 +23,6 @@ import (
 	"github.com/gotidy/ptr"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/pkg/reporter"
 	"github.com/spf13/cobra"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -83,12 +80,14 @@ var ReportCmd = &cobra.Command{
 		}
 		cfg.SetDefaults()
 
-		recorder, err := reporter.NewEventRecorder(ctx, cfg)
-		if err != nil {
-			log.Error(err, "couldn't initialize event recorder")
-			os.
-				Exit(1)
-		}
+		/*
+			recorder, err := reporter.NewEventRecorder(ctx, cfg)
+			if err != nil {
+				log.Error(err, "couldn't initialize event recorder")
+				os.
+					Exit(1)
+			}
+		*/
 
 		task, err := reporter.NewTask(
 			ctx,
@@ -96,18 +95,20 @@ var ReportCmd = &cobra.Command{
 			cfg,
 		)
 
-		job := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      os.Getenv("POD_NAME"),
-				Namespace: os.Getenv("POD_NAMESPACE"),
-			},
-		}
+		/*
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      os.Getenv("POD_NAME"),
+					Namespace: os.Getenv("POD_NAMESPACE"),
+				},
+			}
+		*/
 
 		if err != nil {
 			var comp *reporter.ReportJobError
 			if errors.As(err, &comp) {
 				log.Error(err, "report job error")
-				recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
+				//recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
 			}
 			log.Error(err, "couldn't initialize task")
 			os.Exit(1)

--- a/reporter/v2/cmd/reporter/report/report.go
+++ b/reporter/v2/cmd/reporter/report/report.go
@@ -80,36 +80,13 @@ var ReportCmd = &cobra.Command{
 		}
 		cfg.SetDefaults()
 
-		/*
-			recorder, err := reporter.NewEventRecorder(ctx, cfg)
-			if err != nil {
-				log.Error(err, "couldn't initialize event recorder")
-				os.
-					Exit(1)
-			}
-		*/
-
 		task, err := reporter.NewTask(
 			ctx,
 			reporter.ReportName{Namespace: namespace, Name: name},
 			cfg,
 		)
 
-		/*
-			job := &batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      os.Getenv("POD_NAME"),
-					Namespace: os.Getenv("POD_NAMESPACE"),
-				},
-			}
-		*/
-
 		if err != nil {
-			var comp *reporter.ReportJobError
-			if errors.As(err, &comp) {
-				log.Error(err, "report job error")
-				//recorder.Event(job, corev1.EventTypeWarning, "ReportJobError", "No insights")
-			}
 			log.Error(err, "couldn't initialize task")
 			os.Exit(1)
 		}

--- a/reporter/v2/pkg/reporter/reconcile_task.go
+++ b/reporter/v2/pkg/reporter/reconcile_task.go
@@ -16,11 +16,18 @@ package reporter
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
+	"emperror.dev/errors"
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,9 +36,26 @@ type ReconcileTask struct {
 	Config    *Config
 	K8SScheme *runtime.Scheme
 	Namespace
+	recorder record.EventRecorder
 }
 
 func (r *ReconcileTask) Run(ctx context.Context) error {
+
+	err := r.run(ctx)
+
+	if err != nil {
+		terr := r.recordTaskError(ctx, err)
+		if terr != nil {
+			logger.Error(terr, "error recording task error to events")
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileTask) run(ctx context.Context) error {
 	logger.Info("reconcile run start")
 	meterReports := marketplacev1alpha1.MeterReportList{}
 
@@ -140,6 +164,32 @@ func (r *ReconcileTask) UploadTask(ctx context.Context) error {
 	if err != nil {
 		logger.Error(err, "error running task")
 		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileTask) recordTaskError(ctx context.Context, err error) error {
+
+	var comp *ReportJobError
+
+	if errors.As(err, &comp) {
+
+		logger.Error(err, "ReportJobError")
+
+		job := &batchv1.Job{}
+		err = r.K8SClient.Get(ctx, types.NamespacedName{Name: os.Getenv("JOB_NAME"), Namespace: os.Getenv("POD_NAMESPACE")}, job)
+		if err != nil {
+			return err
+		}
+
+		jobref, err := reference.GetReference(r.K8SScheme, job)
+		if err != nil {
+			return err
+		}
+
+		r.recorder.Event(jobref, corev1.EventTypeWarning, "ReportJobError", "No insights")
+		logger.Info("ReportJobError event send")
 	}
 
 	return nil

--- a/reporter/v2/pkg/reporter/reconcile_task.go
+++ b/reporter/v2/pkg/reporter/reconcile_task.go
@@ -16,6 +16,7 @@ package reporter
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -175,8 +176,6 @@ func (r *ReconcileTask) recordTaskError(ctx context.Context, err error) error {
 
 	if errors.As(err, &comp) {
 
-		logger.Error(err, "ReportJobError")
-
 		job := &batchv1.Job{}
 		err = r.K8SClient.Get(ctx, types.NamespacedName{Name: os.Getenv("JOB_NAME"), Namespace: os.Getenv("POD_NAMESPACE")}, job)
 		if err != nil {
@@ -188,8 +187,7 @@ func (r *ReconcileTask) recordTaskError(ctx context.Context, err error) error {
 			return err
 		}
 
-		r.recorder.Event(jobref, corev1.EventTypeWarning, "ReportJobError", "No insights")
-		logger.Info("ReportJobError event send")
+		r.recorder.Event(jobref, corev1.EventTypeWarning, "ReportJobError", fmt.Sprintf("Report Job Error: %v", comp.Error()))
 	}
 
 	return nil

--- a/reporter/v2/pkg/reporter/reconcile_task.go
+++ b/reporter/v2/pkg/reporter/reconcile_task.go
@@ -69,7 +69,8 @@ func (r *ReconcileTask) Run(ctx context.Context) error {
 	if r.CanRunUploadTask(ctx) {
 		if err := r.UploadTask(ctx); err != nil {
 			logger.Error(err, "error uploading files from data service")
-			errs = append(errs, err)
+			return err
+			// errs = append(errs, err)
 		}
 	}
 

--- a/reporter/v2/pkg/reporter/reconcile_task.go
+++ b/reporter/v2/pkg/reporter/reconcile_task.go
@@ -95,7 +95,6 @@ func (r *ReconcileTask) run(ctx context.Context) error {
 		if err := r.UploadTask(ctx); err != nil {
 			logger.Error(err, "error uploading files from data service")
 			return err
-			// errs = append(errs, err)
 		}
 	}
 

--- a/reporter/v2/pkg/reporter/task.go
+++ b/reporter/v2/pkg/reporter/task.go
@@ -333,10 +333,14 @@ func getMeterDefinitionReferences(
 	return
 }
 
-func provideReporterEventBroadcaster(schemeIn *runtime.Scheme, kubeclientset kubernetes.Interface) record.EventRecorder {
+func provideReporterEventBroadcaster(kubeclientset kubernetes.Interface) record.EventBroadcaster {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartStructuredLogging(0)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	return eventBroadcaster
+}
+
+func provideReporterEventRecorder(eventBroadcaster record.EventBroadcaster, schemeIn *runtime.Scheme) record.EventRecorder {
 	recorder := eventBroadcaster.NewRecorder(schemeIn, corev1.EventSource{Component: "reporter"})
 	return recorder
 }

--- a/reporter/v2/pkg/reporter/task.go
+++ b/reporter/v2/pkg/reporter/task.go
@@ -42,7 +42,10 @@ import (
 	rhmclient "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/client"
 	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/prometheus"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -327,6 +330,14 @@ func getMeterDefinitionReferences(
 	})
 
 	return
+}
+
+func provideReporterEventBroadcaster(schemeIn *runtime.Scheme, kubeclientset kubernetes.Interface) record.EventRecorder {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(schemeIn, corev1.EventSource{Component: "reporter"})
+	return recorder
 }
 
 func provideScheme() *runtime.Scheme {

--- a/reporter/v2/pkg/reporter/task.go
+++ b/reporter/v2/pkg/reporter/task.go
@@ -29,6 +29,7 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -350,5 +351,6 @@ func provideScheme() *runtime.Scheme {
 	utilruntime.Must(opsrcv1.AddToScheme(scheme))
 	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
 	return scheme
 }

--- a/reporter/v2/pkg/reporter/uploader.go
+++ b/reporter/v2/pkg/reporter/uploader.go
@@ -557,38 +557,30 @@ func provideProductionInsightsConfig(
 	dockerConfigBytes, ok := secret.Data[".dockerconfigjson"]
 
 	if !ok {
-		return nil, errors.Wrap(&ReportJobError{
+		return nil, errors.WithStack(&ReportJobError{
 			ErrorMessage: "failed to find .dockerconfigjson in secret openshift-config/pull-secret",
 			Err:          errors.New("report job error"),
-		}, "failed to find .dockerconfigjson in secret openshift-config/pull-secret")
+		})
 	}
 
 	var dockerObj interface{}
 	err := json.Unmarshal(dockerConfigBytes, &dockerObj)
 
 	if err != nil {
-		return nil, errors.Wrap(&ReportJobError{
+		return nil, errors.WithStack(&ReportJobError{
 			ErrorMessage: "failed to unmarshal .dockerconfigjson from secret openshift-config/pull-secret",
 			Err:          err,
-		}, "failed to unmarshal .dockerconfigjson from secret openshift-config/pull-secret")
+		})
 	}
 
 	cloudAuthPath := jsonpath.New("cloudauthpath")
 	err = cloudAuthPath.Parse(`{.auths.cloud\.openshift\.com.auth}`)
 
-	/*
-		if err != nil {
-			return nil, errors.WithStack(ReportJobError{
-				ErrorMessage: "failed to get jsonpath of cloud token",
-				Err:          err,
-			})
-		}
-	*/
 	if err != nil {
-		return nil, &ReportJobError{
-			ErrorMessage: "failed to get jsonpath of cloud token",
+		return nil, errors.WithStack(&ReportJobError{
+			ErrorMessage: "failed to parse auth token in .dockerconfigjson from secret openshift-config/pull-secret",
 			Err:          err,
-		}
+		})
 	}
 
 	buf := new(bytes.Buffer)
@@ -596,7 +588,7 @@ func provideProductionInsightsConfig(
 
 	if err != nil {
 		return nil, errors.WithStack(&ReportJobError{
-			ErrorMessage: "failed to get jsonpath of cloud token",
+			ErrorMessage: "failed to template auth token in .dockerconfigjson from secret openshift-config/pull-secret",
 			Err:          err,
 		})
 	}

--- a/reporter/v2/pkg/reporter/wire.go
+++ b/reporter/v2/pkg/reporter/wire.go
@@ -48,14 +48,13 @@ func NewTask(
 	))
 }
 
-func NewEventRecorder(
+func NewEventBroadcaster(
 	ctx context.Context,
 	erConfig *Config,
-) (record.EventRecorder, error) {
+) (record.EventBroadcaster, error) {
 	panic(wire.Build(
 		config.GetConfig,
 		managers.ProvideSimpleClientSet,
-		provideScheme,
 		provideReporterEventBroadcaster,
 	))
 }
@@ -103,6 +102,7 @@ func NewUploadTask(
 func NewReconcileTask(
 	ctx context.Context,
 	config *Config,
+	broadcaster record.EventBroadcaster,
 	namespace Namespace,
 ) (*ReconcileTask, error) {
 	panic(wire.Build(
@@ -110,6 +110,7 @@ func NewReconcileTask(
 		kconfig.GetConfig,
 		wire.Struct(new(ReconcileTask), "*"),
 		provideScheme,
+		provideReporterEventRecorder,
 		wire.Bind(new(client.Client), new(rhmclient.SimpleClient)),
 	))
 }

--- a/reporter/v2/pkg/reporter/wire.go
+++ b/reporter/v2/pkg/reporter/wire.go
@@ -51,7 +51,7 @@ func NewTask(
 func NewEventBroadcaster(
 	ctx context.Context,
 	erConfig *Config,
-) (record.EventBroadcaster, error) {
+) (record.EventBroadcaster, func(), error) {
 	panic(wire.Build(
 		config.GetConfig,
 		managers.ProvideSimpleClientSet,

--- a/reporter/v2/pkg/reporter/wire.go
+++ b/reporter/v2/pkg/reporter/wire.go
@@ -25,7 +25,9 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/prometheus"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	kconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -43,6 +45,18 @@ func NewTask(
 		provideScheme,
 		wire.Bind(new(client.Client), new(rhmclient.SimpleClient)),
 		kconfig.GetConfig,
+	))
+}
+
+func NewEventRecorder(
+	ctx context.Context,
+	erConfig *Config,
+) (record.EventRecorder, error) {
+	panic(wire.Build(
+		config.GetConfig,
+		managers.ProvideSimpleClientSet,
+		provideScheme,
+		provideReporterEventBroadcaster,
 	))
 }
 

--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -53,17 +53,19 @@ var (
 	_wireLoggerValue = logger
 )
 
-func NewEventBroadcaster(ctx context.Context, erConfig *Config) (record.EventBroadcaster, error) {
+func NewEventBroadcaster(ctx context.Context, erConfig *Config) (record.EventBroadcaster, func(), error) {
 	restConfig, err := config.GetConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	eventBroadcaster := provideReporterEventBroadcaster(clientset)
-	return eventBroadcaster, nil
+	eventBroadcaster, cleanup := provideReporterEventBroadcaster(clientset)
+	return eventBroadcaster, func() {
+		cleanup()
+	}, nil
 }
 
 func NewReporter(task *Task) (*MarketplaceReporter, error) {

--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -53,8 +53,7 @@ var (
 	_wireLoggerValue = logger
 )
 
-func NewEventRecorder(ctx context.Context, erConfig *Config) (record.EventRecorder, error) {
-	scheme := provideScheme()
+func NewEventBroadcaster(ctx context.Context, erConfig *Config) (record.EventBroadcaster, error) {
 	restConfig, err := config.GetConfig()
 	if err != nil {
 		return nil, err
@@ -63,8 +62,8 @@ func NewEventRecorder(ctx context.Context, erConfig *Config) (record.EventRecord
 	if err != nil {
 		return nil, err
 	}
-	eventRecorder := provideReporterEventBroadcaster(scheme, clientset)
-	return eventRecorder, nil
+	eventBroadcaster := provideReporterEventBroadcaster(clientset)
+	return eventBroadcaster, nil
 }
 
 func NewReporter(task *Task) (*MarketplaceReporter, error) {
@@ -163,7 +162,7 @@ var (
 	_wireLoggerValue2 = logger
 )
 
-func NewReconcileTask(ctx context.Context, config2 *Config, namespace Namespace) (*ReconcileTask, error) {
+func NewReconcileTask(ctx context.Context, config2 *Config, broadcaster record.EventBroadcaster, namespace Namespace) (*ReconcileTask, error) {
 	restConfig, err := config.GetConfig()
 	if err != nil {
 		return nil, err
@@ -177,11 +176,13 @@ func NewReconcileTask(ctx context.Context, config2 *Config, namespace Namespace)
 	if err != nil {
 		return nil, err
 	}
+	eventRecorder := provideReporterEventRecorder(broadcaster, scheme)
 	reconcileTask := &ReconcileTask{
 		K8SClient: simpleClient,
 		Config:    config2,
 		K8SScheme: scheme,
 		Namespace: namespace,
+		recorder:  eventRecorder,
 	}
 	return reconcileTask, nil
 }

--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -10,6 +10,8 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/prometheus"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -50,6 +52,20 @@ func NewTask(ctx context.Context, reportName ReportName, taskConfig *Config) (*T
 var (
 	_wireLoggerValue = logger
 )
+
+func NewEventRecorder(ctx context.Context, erConfig *Config) (record.EventRecorder, error) {
+	scheme := provideScheme()
+	restConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	eventRecorder := provideReporterEventBroadcaster(scheme, clientset)
+	return eventRecorder, nil
+}
 
 func NewReporter(task *Task) (*MarketplaceReporter, error) {
 	reporterConfig := task.Config

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -19,3 +19,12 @@ spec:
               # additional args are added in factory
               args:
                 - 'reconcile'
+              env:
+              - name: JOB_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['job-name']
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -285,6 +285,7 @@ rules:
       - watch
       - list
       - create
+      - update
       - patch
   - apiGroups:
       - batch

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -276,6 +276,16 @@ rules:
       - get
       - watch
       - list
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - patch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -286,6 +286,14 @@ rules:
       - list
       - create
       - patch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - watch
+      - list
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
create broadcaster at top level that can optionally be passed to Task functions
task records ReportJobError type to events on the Job object before returning
the Event will send the ReportJobError.ErrorMessage to the Event (not the stack)
Is there anything more specific you want in the Event message?

ReconcileTask.Run was accumulating errors without returning them
Which I modified for CanRunUploadTask, but not range meterReportsToRun
Do we want to do something specific about this?