### PR TITLE
uwm event for DefaultStorageClassNotFound

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -270,8 +270,6 @@ func (r *MeterBaseReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		),
 	)
 
-	r.recorder.Event(instance, "Warning", "DefaultClassNotFound", "test event")
-
 	if !result.Is(Continue) {
 		if result.Is(NotFound) {
 			reqLogger.Info("MeterBase resource not found. Ignoring since object must be deleted.")
@@ -443,6 +441,7 @@ func (r *MeterBaseReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 	if userWorkloadMonitoringEnabled {
 		// Openshift provides Prometheus
 		if result, _ := cc.Do(context.TODO(),
+			Do(r.checkUWMDefaultStorageClassPrereq(instance)...),
 			Do(r.installPrometheusServingCertsCABundle()...),
 			Do(r.installMetricStateDeployment(instance, userWorkloadMonitoringEnabled)...),
 			Do(r.installUserWorkloadMonitoring(instance)...),
@@ -1057,6 +1056,25 @@ func (r *MeterBaseReconciler) installMetricStateDeployment(
 	}
 
 	return actions
+}
+
+// Record a DefaultClassNotFound Event, but do not err
+// User could possibly, but less likely, set up UWM storage without a default
+func (r *MeterBaseReconciler) checkUWMDefaultStorageClassPrereq(
+	instance *marketplacev1alpha1.MeterBase,
+) []ClientAction {
+	return []ClientAction{
+		Call(func() (ClientAction, error) {
+			_, err := utils.GetDefaultStorageClass(r.Client)
+			if err != nil {
+				if errors.Is(err, operrors.DefaultStorageClassNotFound) {
+					r.recorder.Event(instance, "Warning", "DefaultClassNotFound", "Default storage class not found")
+				} else {
+					return nil, err
+				}
+			}
+			return nil, nil
+		})}
 }
 
 func (r *MeterBaseReconciler) installUserWorkloadMonitoring(


### PR DESCRIPTION
- Send an event for DefaultClassNotFound for userWorkloadMonitoring, just as we do with rhm-prometheus setup.
- Send the event, but do not stop reconciliation, as user could have setup a storageclass manually for UWM