### PR TITLE
Bugfix/query label replace meter def namespace

### DIFF
--- a/v2/apis/marketplace/common/prometheus.go
+++ b/v2/apis/marketplace/common/prometheus.go
@@ -37,10 +37,10 @@ const (
 type MeterDefPrometheusLabels struct {
 	UID               string `json:"meter_definition_uid" mapstructure:"meter_definition_uid"`
 	MeterDefName      string `json:"name" mapstructure:"name"`
-	MeterDefNamespace string `json:"namespace,omitempty" mapstructure:"namespace"`
+	MeterDefNamespace string `json:"namespace" mapstructure:"namespace"`
 
 	// UserWorkloadMonitoring will exported_ overlapping labels
-	ExportedMeterDefNamespace string `json:"exported_namespace" mapstructure:"exported_namespace"`
+	ExportedMeterDefNamespace string `json:"exported_namespace,omitempty" mapstructure:"exported_namespace"`
 
 	// Deprecated: metric is now the primary name
 	WorkloadName      string        `json:"workload_name" mapstructure:"workload_name" template:""`

--- a/v2/apis/marketplace/common/prometheus.go
+++ b/v2/apis/marketplace/common/prometheus.go
@@ -207,6 +207,15 @@ func (m *MeterDefPrometheusLabels) PrintTemplate(
 	return result, nil
 }
 
+// UserWorkloadMonitoring will exported_ overlapping labels
+func (m *MeterDefPrometheusLabels) Namespace() string {
+	if len(m.ExportedMeterDefNamespace) != 0 {
+		return m.ExportedMeterDefNamespace
+	} else {
+		return m.MeterDefNamespace
+	}
+}
+
 // MeterDefPrometheusLabelsTemplated is the values of a meter definition
 // templated and with values set ready to be added.
 type MeterDefPrometheusLabelsTemplated struct {

--- a/v2/apis/marketplace/common/prometheus.go
+++ b/v2/apis/marketplace/common/prometheus.go
@@ -37,7 +37,10 @@ const (
 type MeterDefPrometheusLabels struct {
 	UID               string `json:"meter_definition_uid" mapstructure:"meter_definition_uid"`
 	MeterDefName      string `json:"name" mapstructure:"name"`
-	MeterDefNamespace string `json:"namespace" mapstructure:"namespace"`
+	MeterDefNamespace string `json:"namespace,omitempty" mapstructure:"namespace"`
+
+	// UserWorkloadMonitoring will exported_ overlapping labels
+	ExportedMeterDefNamespace string `json:"exported_namespace" mapstructure:"exported_namespace"`
 
 	// Deprecated: metric is now the primary name
 	WorkloadName      string        `json:"workload_name" mapstructure:"workload_name" template:""`

--- a/v2/pkg/prometheus/query.go
+++ b/v2/pkg/prometheus/query.go
@@ -72,7 +72,7 @@ func NewPromQueryFromLabels(
 		Type:   workloadType,
 		MeterDef: types.NamespacedName{
 			Name:      meterDefLabels.MeterDefName,
-			Namespace: meterDefLabels.MeterDefNamespace,
+			Namespace: getMeterDefNamespace(meterDefLabels),
 		},
 		Query:         meterDefLabels.MetricQuery,
 		Start:         start,
@@ -109,7 +109,7 @@ func PromQueryFromLabels(
 		Type:   workloadType,
 		MeterDef: types.NamespacedName{
 			Name:      meterDefLabels.MeterDefName,
-			Namespace: meterDefLabels.MeterDefNamespace,
+			Namespace: getMeterDefNamespace(meterDefLabels),
 		},
 		Query:         meterDefLabels.MetricQuery,
 		Start:         start,
@@ -407,4 +407,13 @@ func (p *PrometheusAPI) MeterDefLabelValues() (model.LabelValues, v1.Warnings, e
 	}
 
 	return labelValues, warnings, nil
+}
+
+// UserWorkloadMonitoring will exported_ overlapping labels
+func getMeterDefNamespace(meterDefLabels *common.MeterDefPrometheusLabels) string {
+	if len(meterDefLabels.ExportedMeterDefNamespace) != 0 {
+		return meterDefLabels.ExportedMeterDefNamespace
+	} else {
+		return meterDefLabels.MeterDefNamespace
+	}
 }

--- a/v2/pkg/prometheus/query.go
+++ b/v2/pkg/prometheus/query.go
@@ -72,7 +72,7 @@ func NewPromQueryFromLabels(
 		Type:   workloadType,
 		MeterDef: types.NamespacedName{
 			Name:      meterDefLabels.MeterDefName,
-			Namespace: getMeterDefNamespace(meterDefLabels),
+			Namespace: meterDefLabels.Namespace(),
 		},
 		Query:         meterDefLabels.MetricQuery,
 		Start:         start,
@@ -109,7 +109,7 @@ func PromQueryFromLabels(
 		Type:   workloadType,
 		MeterDef: types.NamespacedName{
 			Name:      meterDefLabels.MeterDefName,
-			Namespace: getMeterDefNamespace(meterDefLabels),
+			Namespace: meterDefLabels.Namespace(),
 		},
 		Query:         meterDefLabels.MetricQuery,
 		Start:         start,
@@ -407,13 +407,4 @@ func (p *PrometheusAPI) MeterDefLabelValues() (model.LabelValues, v1.Warnings, e
 	}
 
 	return labelValues, warnings, nil
-}
-
-// UserWorkloadMonitoring will exported_ overlapping labels
-func getMeterDefNamespace(meterDefLabels *common.MeterDefPrometheusLabels) string {
-	if len(meterDefLabels.ExportedMeterDefNamespace) != 0 {
-		return meterDefLabels.ExportedMeterDefNamespace
-	} else {
-		return meterDefLabels.MeterDefNamespace
-	}
 }


### PR DESCRIPTION
With UWM enabled, UWM sets namespace to the namespace of what endpoint was scraped (openshift-redhat-marketplace/rhm-metric-state)
and sets exported_namespace to the scraped meterdef_metric_label_info/namespace

https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/user-workload-monitoring.md#multitenancy

In reporter/discover.go/getQueries
the matrixVals contain

exported_namespace as correct meterdef namespace 
namespace as operator namespace

When the labels hit the Marshal/Unmarshal via

buildPromQuery/NewPromQueryFromLabels

MeterDefNamespace is set to the non-exported namespace, which will always be openshift-redhat-marketplace
instead of the namespace of the MeterDefinition

To handle the UWM case
Unmarshal for exported_namespace field
If the field was set, use it as the MeterDef namespace