### PR TITLE
Bugfix/rrs3 finalizers

### DIFF
--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -189,7 +189,9 @@ func (r *RazeeDeploymentReconciler) SetupWithManager(mgr manager.Manager) error 
 				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 300)},
 			),
 		}).
-		Watches(&source.Kind{Type: &marketplacev1alpha1.RazeeDeployment{}}, &handler.EnqueueRequestForObject{}).
+		Watches(&source.Kind{Type: &marketplacev1alpha1.RazeeDeployment{}},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &batch.Job{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &marketplacev1alpha1.RazeeDeployment{},
@@ -208,6 +210,14 @@ func (r *RazeeDeploymentReconciler) SetupWithManager(mgr manager.Manager) error 
 				ToRequests: mapFn,
 			},
 			builder.WithPredicates(pp)).
+		/*
+			Watches(
+				&source.Kind{Type: &marketplacev1alpha1.RemoteResourceS3{}},
+				&handler.EnqueueRequestForOwner{
+					OwnerType: &marketplacev1alpha1.RazeeDeployment{},
+				},
+				builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		*/
 		Complete(r)
 }
 
@@ -1072,59 +1082,97 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 	//Only create the parent s3 resource when the razee deployment is enabled
 	if rrs3DeploymentEnabled {
 
-		parentRRS3 := &marketplacev1alpha1.RemoteResourceS3{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{
-			Name:      utils.PARENT_RRS3_RESOURCE_NAME,
-			Namespace: *instance.Spec.TargetNamespace},
-			parentRRS3)
+		var op controllerutil.OperationResult
+		parentRRS3 := r.makeParentRemoteResourceS3(instance)
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			op, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, parentRRS3, func() error {
+				r.updateParentRemoteResourceS3(parentRRS3, instance)
+				return r.factory.SetOwnerReference(instance, parentRRS3)
+			})
+			return err
+		})
 		if err != nil {
-			if errors.IsNotFound(err) {
-				reqLogger.V(0).Info("Resource does not exist", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
-				parentRRS3 := r.makeParentRemoteResourceS3(instance)
+			return reconcile.Result{}, err
+		}
 
-				err = r.Client.Create(context.TODO(), parentRRS3)
-				if err != nil {
-					reqLogger.Info("Failed to create resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+		message := "ParentRRS3 install finished"
+		instance.Status.Conditions.SetCondition(status.Condition{
+			Type:    marketplacev1alpha1.ConditionInstalling,
+			Status:  corev1.ConditionTrue,
+			Reason:  marketplacev1alpha1.ReasonParentRRS3Installed,
+			Message: message,
+		})
+
+		_ = r.Client.Status().Update(context.TODO(), instance)
+
+		reqLogger.Info(fmt.Sprintf("Resource %v successfully", op), "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+
+		/*
+
+			parentRRS3 := &marketplacev1alpha1.RemoteResourceS3{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{
+				Name:      utils.PARENT_RRS3_RESOURCE_NAME,
+				Namespace: *instance.Spec.TargetNamespace},
+				parentRRS3)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					reqLogger.V(0).Info("Resource does not exist", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+					parentRRS3 := r.makeParentRemoteResourceS3(instance)
+					r.factory.SetOwnerReference(instance, parentRRS3)
+
+					err = r.Client.Create(context.TODO(), parentRRS3)
+					if err != nil {
+						reqLogger.Info("Failed to create resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+						return reconcile.Result{}, err
+					}
+					message := "ParentRRS3 install finished"
+					instance.Status.Conditions.SetCondition(status.Condition{
+						Type:    marketplacev1alpha1.ConditionInstalling,
+						Status:  corev1.ConditionTrue,
+						Reason:  marketplacev1alpha1.ReasonParentRRS3Installed,
+						Message: message,
+					})
+
+					_ = r.Client.Status().Update(context.TODO(), instance)
+
+					reqLogger.Info("Resource created successfully", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+					return reconcile.Result{Requeue: true}, nil
+				} else {
+					reqLogger.Info("Failed to get resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
 					return reconcile.Result{}, err
 				}
-				message := "ParentRRS3 install finished"
-				instance.Status.Conditions.SetCondition(status.Condition{
-					Type:    marketplacev1alpha1.ConditionInstalling,
-					Status:  corev1.ConditionTrue,
-					Reason:  marketplacev1alpha1.ReasonParentRRS3Installed,
-					Message: message,
-				})
+			} else { // ensure parentRRS3 has OwnerRef
+				r.factory.SetOwnerReference(instance, parentRRS3)
+				err = r.Client.Update(context.TODO(), parentRRS3)
+				if err != nil {
+					reqLogger.Info("Failed to update resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+					return reconcile.Result{}, err
+				}
 
-				_ = r.Client.Status().Update(context.TODO(), instance)
+			}
 
-				reqLogger.Info("Resource created successfully", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+			reqLogger.V(0).Info("Resource already exists", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+
+			newParentValues := r.makeParentRemoteResourceS3(instance)
+			updatedParentRRS3 := parentRRS3.DeepCopy()
+			updatedParentRRS3.Spec = newParentValues.Spec
+
+			if !reflect.DeepEqual(updatedParentRRS3.Spec, parentRRS3.Spec) {
+				reqLogger.Info("Change detected on resource", updatedParentRRS3.GetName(), "update")
+
+				reqLogger.Info("Updating resource", "resource: ", utils.PARENT_RRS3_RESOURCE_NAME)
+				err = r.Client.Update(context.TODO(), updatedParentRRS3)
+				if err != nil {
+					reqLogger.Info("Failed to update resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+					return reconcile.Result{}, err
+				}
+				reqLogger.Info("Resource updated successfully", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
 				return reconcile.Result{Requeue: true}, nil
-			} else {
-				reqLogger.Info("Failed to get resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
-				return reconcile.Result{}, err
 			}
-		}
 
-		reqLogger.V(0).Info("Resource already exists", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
+			reqLogger.V(0).Info("No change detected on resource", "resource", updatedParentRRS3.GetName())
 
-		newParentValues := r.makeParentRemoteResourceS3(instance)
-		updatedParentRRS3 := parentRRS3.DeepCopy()
-		updatedParentRRS3.Spec = newParentValues.Spec
-
-		if !reflect.DeepEqual(updatedParentRRS3.Spec, parentRRS3.Spec) {
-			reqLogger.Info("Change detected on resource", updatedParentRRS3.GetName(), "update")
-
-			reqLogger.Info("Updating resource", "resource: ", utils.PARENT_RRS3_RESOURCE_NAME)
-			err = r.Client.Update(context.TODO(), updatedParentRRS3)
-			if err != nil {
-				reqLogger.Info("Failed to update resource", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
-				return reconcile.Result{}, err
-			}
-			reqLogger.Info("Resource updated successfully", "resource", utils.PARENT_RRS3_RESOURCE_NAME)
-			return reconcile.Result{Requeue: true}, nil
-		}
-
-		reqLogger.V(0).Info("No change detected on resource", "resource", updatedParentRRS3.GetName())
+		*/
 
 		razeePrereqs = append(razeePrereqs, utils.PARENT_RRS3_RESOURCE_NAME)
 
@@ -1297,6 +1345,7 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 	}
 
 	reqLogger.Info("End of reconcile")
+	reqLogger.Info("dac debug", "reconcileResult", reconcile.Result{})
 	return reconcile.Result{}, nil
 
 }
@@ -1464,39 +1513,82 @@ func (r *RazeeDeploymentReconciler) makeCOSReaderSecret(instance *marketplacev1a
 }
 
 // Creates the "parent" RemoteResourceS3 and applies the name of the cos-reader-key and ChildUrl constructed during reconciliation of the rhm-operator-secret
-func (r *RazeeDeploymentReconciler) makeParentRemoteResourceS3(instance *marketplacev1alpha1.RazeeDeployment) *marketplacev1alpha1.RemoteResourceS3 {
-	return &marketplacev1alpha1.RemoteResourceS3{
+func (r *RazeeDeploymentReconciler) makeParentRemoteResourceS3(
+	instance *marketplacev1alpha1.RazeeDeployment) *marketplacev1alpha1.RemoteResourceS3 {
+
+	return r.updateParentRemoteResourceS3(&marketplacev1alpha1.RemoteResourceS3{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.PARENT_RRS3_RESOURCE_NAME,
 			Namespace: *instance.Spec.TargetNamespace,
 		},
-		Spec: marketplacev1alpha1.RemoteResourceS3Spec{
-			Auth: marketplacev1alpha1.Auth{
-				Iam: &marketplacev1alpha1.Iam{
-					ResponseType: "cloud_iam",
-					GrantType:    "urn:ibm:params:oauth:grant-type:apikey",
-					URL:          "https://iam.cloud.ibm.com/identity/token",
-					APIKeyRef: marketplacev1alpha1.APIKeyRef{
-						ValueFrom: marketplacev1alpha1.ValueFrom{
-							SecretKeyRef: corev1.SecretKeySelector{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: utils.COS_READER_KEY_NAME,
+	}, instance)
+
+	/*
+		return &marketplacev1alpha1.RemoteResourceS3{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      utils.PARENT_RRS3_RESOURCE_NAME,
+				Namespace: *instance.Spec.TargetNamespace,
+			},
+			Spec: marketplacev1alpha1.RemoteResourceS3Spec{
+				Auth: marketplacev1alpha1.Auth{
+					Iam: &marketplacev1alpha1.Iam{
+						ResponseType: "cloud_iam",
+						GrantType:    "urn:ibm:params:oauth:grant-type:apikey",
+						URL:          "https://iam.cloud.ibm.com/identity/token",
+						APIKeyRef: marketplacev1alpha1.APIKeyRef{
+							ValueFrom: marketplacev1alpha1.ValueFrom{
+								SecretKeyRef: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: utils.COS_READER_KEY_NAME,
+									},
+									Key: "accesskey",
 								},
-								Key: "accesskey",
 							},
 						},
 					},
 				},
+				Requests: []marketplacev1alpha1.Request{
+					{
+						Options: marketplacev1alpha1.S3Options{
+							URL: *instance.Spec.ChildUrl,
+						},
+					},
+				},
 			},
-			Requests: []marketplacev1alpha1.Request{
-				{
-					Options: marketplacev1alpha1.S3Options{
-						URL: *instance.Spec.ChildUrl,
+		}
+	*/
+}
+
+func (r *RazeeDeploymentReconciler) updateParentRemoteResourceS3(parentRRS3 *marketplacev1alpha1.RemoteResourceS3, instance *marketplacev1alpha1.RazeeDeployment) *marketplacev1alpha1.RemoteResourceS3 {
+
+	parentRRS3.Spec = marketplacev1alpha1.RemoteResourceS3Spec{
+		Auth: marketplacev1alpha1.Auth{
+			Iam: &marketplacev1alpha1.Iam{
+				ResponseType: "cloud_iam",
+				GrantType:    "urn:ibm:params:oauth:grant-type:apikey",
+				URL:          "https://iam.cloud.ibm.com/identity/token",
+				APIKeyRef: marketplacev1alpha1.APIKeyRef{
+					ValueFrom: marketplacev1alpha1.ValueFrom{
+						SecretKeyRef: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: utils.COS_READER_KEY_NAME,
+							},
+							Key: "accesskey",
+						},
 					},
 				},
 			},
 		},
+		Requests: []marketplacev1alpha1.Request{
+			{
+				Options: marketplacev1alpha1.S3Options{
+					URL: *instance.Spec.ChildUrl,
+				},
+			},
+		},
 	}
+
+	return parentRRS3
 }
 
 //Undeploy the razee deployment and parent

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -189,9 +189,7 @@ func (r *RazeeDeploymentReconciler) SetupWithManager(mgr manager.Manager) error 
 				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 300)},
 			),
 		}).
-		Watches(&source.Kind{Type: &marketplacev1alpha1.RazeeDeployment{}},
-			&handler.EnqueueRequestForObject{},
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&source.Kind{Type: &marketplacev1alpha1.RazeeDeployment{}}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &batch.Job{}}, &handler.EnqueueRequestForOwner{
 			IsController: true,
 			OwnerType:    &marketplacev1alpha1.RazeeDeployment{},
@@ -1455,41 +1453,6 @@ func (r *RazeeDeploymentReconciler) makeParentRemoteResourceS3(
 			Namespace: *instance.Spec.TargetNamespace,
 		},
 	}, instance)
-
-	/*
-		return &marketplacev1alpha1.RemoteResourceS3{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      utils.PARENT_RRS3_RESOURCE_NAME,
-				Namespace: *instance.Spec.TargetNamespace,
-			},
-			Spec: marketplacev1alpha1.RemoteResourceS3Spec{
-				Auth: marketplacev1alpha1.Auth{
-					Iam: &marketplacev1alpha1.Iam{
-						ResponseType: "cloud_iam",
-						GrantType:    "urn:ibm:params:oauth:grant-type:apikey",
-						URL:          "https://iam.cloud.ibm.com/identity/token",
-						APIKeyRef: marketplacev1alpha1.APIKeyRef{
-							ValueFrom: marketplacev1alpha1.ValueFrom{
-								SecretKeyRef: corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: utils.COS_READER_KEY_NAME,
-									},
-									Key: "accesskey",
-								},
-							},
-						},
-					},
-				},
-				Requests: []marketplacev1alpha1.Request{
-					{
-						Options: marketplacev1alpha1.S3Options{
-							URL: *instance.Spec.ChildUrl,
-						},
-					},
-				},
-			},
-		}
-	*/
 }
 
 func (r *RazeeDeploymentReconciler) updateParentRemoteResourceS3(parentRRS3 *marketplacev1alpha1.RemoteResourceS3, instance *marketplacev1alpha1.RazeeDeployment) *marketplacev1alpha1.RemoteResourceS3 {


### PR DESCRIPTION
Since the RazeeDeploymentController creates the RRS3 parent
Watch Owned RemoteResourceS3, updates only on generation change, as the RemoteResourceS3Reconciler does update status
Simplify the previous parentRRS3 create/if-updated logic to use the controllerutil.CreateOrUpdate
Split makeParentRemoteResourceS3 func to make a updateParentRemoteResourceS3 funcs for CreateOrUpdate


This fixes two cases

1. If a user simply deletes remoteresources3/parent, the reconciler will not recreate it until either the controller is restarted, or another watched resource triggers the RazeeDeploymentReconciler

2. A reinstall case
- delete deployments; all pods are deleted
- delete remoteresources3 --all; now stuck in delete state, due to finalizers with no controller
- redeploy operator
- no remoteresources3 resources exist; all cleaned up by reinstalled remoteresources3-controller controller; rrs3 parent/child not automatically recreated
- As per 1. If pods are recycled, remoteresources3 parent will be created