### PR TITLE
bugfix: fixing 4.8 secret issues

### DIFF
--- a/base/base.Dockerfile
+++ b/base/base.Dockerfile
@@ -8,17 +8,17 @@ ARG OS=${TARGETOS:-linux}
 ENV VERSION=${VERSION} OS=${OS} ARCH=${ARCH}
 
 RUN dnf -y install git make yum gzip \
-  && dnf update \
+  && dnf -y update \
   && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
-  && yum clean all \
-  && dnf clean all \
+  && yum -y clean all \
+  && dnf -y clean all \
   && rm -rf /var/cache/yum
 
 
 RUN curl -o go.tar.gz https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
   rm -rf /usr/local/go && \
   sha256sum go.tar.gz && \
-  chmod ugo+r go.tar.gz && \
   tar -C /usr/local -xzf go.tar.gz && \
   echo 'PATH=$PATH:/usr/local/go/bin' >> /etc/profile && \
+  echo 'PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile \
   echo 'PATH=$PATH:/usr/local/go/bin' >> $HOME/.profile

--- a/v2/apis/marketplace/v1alpha1/zz_generated.deepcopy.go
+++ b/v2/apis/marketplace/v1alpha1/zz_generated.deepcopy.go
@@ -984,7 +984,7 @@ func (in *RazeeDeploymentStatus) DeepCopyInto(out *RazeeDeploymentStatus) {
 	if in.JobConditions != nil {
 		in, out := &in.JobConditions, &out.JobConditions
 		*out = new(batchv1.JobCondition)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.JobState != nil {
 		in, out := &in.JobState, &out.JobState

--- a/v2/assets/metric-state/secret.yaml
+++ b/v2/assets/metric-state/secret.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: redhat-marketplace-service-account-token
+  generateName: redhat-marketplace-service-account-token-
+  labels:
+    name: redhat-marketplace-service-account-token
   annotations:
-    kubernetes.io/service-account.name: redhat-marketplace-prometheus
+    kubernetes.io/service-account.name: redhat-marketplace-operator
 type: kubernetes.io/service-account-token

--- a/v2/assets/razee/rrs3-controller-deployment.yaml
+++ b/v2/assets/razee/rrs3-controller-deployment.yaml
@@ -24,10 +24,7 @@ spec:
       name: rhm-remoteresources3-controller
     spec:
       containers:
-        - args:
-            - --namespace
-            - $POD_NAMESPACE
-          env:
+        - env:
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/v2/assets/razee/watch-keeper-deployment.yaml
+++ b/v2/assets/razee/watch-keeper-deployment.yaml
@@ -24,88 +24,85 @@ spec:
       name: rhm-watch-keeper
     spec:
       containers:
-      - args:
-        - --namespace
-        - $POD_NAMESPACE
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8089
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: authcheck
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /readyz
-            port: 8089
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 20m
-            memory: 40Mi
-          requests:
-            cpu: 10m
-            memory: 20Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-      - env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: NODE_ENV
-          value: production
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          exec:
-            command:
-            - sh/liveness.sh
-          failureThreshold: 1
-          initialDelaySeconds: 600
-          periodSeconds: 300
-          successThreshold: 1
-          timeoutSeconds: 30
-        name: watch-keeper
-        resources:
-          limits:
-            cpu: 400m
-            memory: 500Mi
-          requests:
-            cpu: 50m
-            memory: 100Mi
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
-        - mountPath: /home/node/envs/watch-keeper-config
-          name: watch-keeper-config
-          readOnly: true
-        - mountPath: /home/node/envs/watch-keeper-secret
-          name: watch-keeper-secret
-          readOnly: true
+        - env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8089
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: authcheck
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8089
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 20m
+              memory: 40Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+        - env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: NODE_ENV
+              value: production
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - sh/liveness.sh
+            failureThreshold: 1
+            initialDelaySeconds: 600
+            periodSeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 30
+          name: watch-keeper
+          resources:
+            limits:
+              cpu: 400m
+              memory: 500Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /home/node/envs/watch-keeper-config
+              name: watch-keeper-config
+              readOnly: true
+            - mountPath: /home/node/envs/watch-keeper-secret
+              name: watch-keeper-secret
+              readOnly: true
       serviceAccountName: redhat-marketplace-watch-keeper
       volumes:
-      - configMap:
-          defaultMode: 288
+        - configMap:
+            defaultMode: 288
+            name: watch-keeper-config
+            optional: false
           name: watch-keeper-config
-          optional: false
-        name: watch-keeper-config
-      - name: watch-keeper-secret
-        secret:
-          defaultMode: 256
-          optional: false
-          secretName: watch-keeper-secret
+        - name: watch-keeper-secret
+          secret:
+            defaultMode: 256
+            optional: false
+            secretName: watch-keeper-secret

--- a/v2/config/crd/bases/marketplace.redhat.com_marketplaceconfigs.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_marketplaceconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: marketplaceconfigs.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterbases.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterbases.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: meterbases.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterdefinitions.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: meterdefinitions.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterreports.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterreports.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: meterreports.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_razeedeployments.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_razeedeployments.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: razeedeployments.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_remoteresources3s.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_remoteresources3s.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: remoteresources3s.marketplace.redhat.com
 spec:
@@ -262,6 +262,7 @@ spec:
               description: Touched is if the status has been touched
               type: boolean
           type: object
+          x-kubernetes-preserve-unknown-fields: true
       type: object
   version: v1alpha1
   versions:

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
 - nonResourceURLs:
   - /api/v1/query
   - /api/v1/query_range
+  - /api/v1/targets
   verbs:
   - create
   - get
@@ -507,6 +508,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - marketplace.redhat.com
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - marketplace.redhat.com
   resources:

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -658,7 +658,7 @@ func (r *MeterBaseReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 	// Provide Status on Prometheus ActiveTargets
 	targets, err := r.healthBadActiveTargets(cc, userWorkloadMonitoringEnabled, reqLogger)
 	if err != nil {
-		return reconcile.Result{RequeueAfter: time.Minute * 1}, err
+		return reconcile.Result{}, err
 	}
 
 	var condition status.Condition

--- a/v2/controllers/marketplace/meterreport_controller.go
+++ b/v2/controllers/marketplace/meterreport_controller.go
@@ -57,7 +57,7 @@ var _ reconcile.Reconciler = &MeterReportReconciler{}
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=marketplace.redhat.com,resources=meterreports;meterreports/status;meterreports/finalizers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=meterreports;meterreports/status;meterreports/finalizers,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:urls=/api/v1/query;/api/v1/query_range,verbs=get;create
+// +kubebuilder:rbac:urls=/api/v1/query;/api/v1/query_range;/api/v1/targets,verbs=get;create
 
 // MeterReportReconciler reconciles a MeterReport object
 type MeterReportReconciler struct {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -111,7 +111,7 @@ type ControllerValues struct {
 }
 
 type MeterBaseValues struct {
-	TransitionTime time.Duration `env:"METERBASE_TRANSITION_TIME" envDefault:"24h" json:"transitionTime"`
+	TransitionTime time.Duration `env:"METERBASE_TRANSITION_TIME" envDefault:"72h" json:"transitionTime"`
 }
 
 // ReportConfig stores some changeable information for creating a report

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -799,6 +799,12 @@ func (f *Factory) MetricStateDeployment() (*appsv1.Deployment, error) {
 	return d, nil
 }
 
+func (f *Factory) ServiceAccountPullSecret() (*corev1.Secret, error) {
+	s, err := NewSecret(MustAssetReader(MetricStateRHMOperatorSecret))
+	s.Namespace = f.namespace
+	return s, err
+}
+
 func (f *Factory) MetricStateServiceMonitor(secretName *string) (*monitoringv1.ServiceMonitor, error) {
 	fileName := MetricStateServiceMonitorV45
 	if f.operatorConfig.HasOpenshift() && f.operatorConfig.Infrastructure.OpenshiftParsedVersion().GTE(utils.ParsedVersion460) {

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -119,7 +119,7 @@ func (f *Factory) ReplaceImages(container *corev1.Container) error {
 		container.Image = f.config.RelatedImages.MetricState
 	case container.Name == "authcheck":
 		container.Image = f.config.RelatedImages.AuthChecker
-		container.Args = []string{"--namespace", "$POD_NAMESPACE"}
+		container.Args = []string{}
 		container.LivenessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/v2/pkg/prometheus/promcfg.go
+++ b/v2/pkg/prometheus/promcfg.go
@@ -23,7 +23,7 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/blang/semver"
-	log "github.com/go-logr/logr"
+	logf "github.com/go-logr/logr"
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
@@ -46,10 +46,10 @@ var (
 )
 
 type configGenerator struct {
-	logger log.Logger
+	logger logf.Logger
 }
 
-func NewConfigGenerator(logger log.Logger) *configGenerator {
+func NewConfigGenerator(logger logf.Logger) *configGenerator {
 	cg := &configGenerator{
 		logger: logger,
 	}

--- a/v2/pkg/prometheus/prometheus_api.go
+++ b/v2/pkg/prometheus/prometheus_api.go
@@ -20,7 +20,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
-	"github.com/prometheus/common/log"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
 	corev1 "k8s.io/api/core/v1"

--- a/v2/pkg/prometheus/thanos_api.go
+++ b/v2/pkg/prometheus/thanos_api.go
@@ -19,7 +19,6 @@ import (
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
-	"github.com/prometheus/common/log"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	. "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils"
 	corev1 "k8s.io/api/core/v1"

--- a/v2/pkg/prometheus/thanos_client.go
+++ b/v2/pkg/prometheus/thanos_client.go
@@ -19,7 +19,6 @@ import (
 
 	"emperror.dev/errors"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/log"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/v2/pkg/utils/predicates/predicates.go
+++ b/v2/pkg/utils/predicates/predicates.go
@@ -90,8 +90,8 @@ func (s *SyncedMapHandler) Cleanup() {
 
 	deleteKeys := []types.NamespacedName{}
 
-	for key, value := range s.data {
-		if !s.exists(key) || !s.exists(value) {
+	for key := range s.data {
+		if !s.exists(key) {
 			deleteKeys = append(deleteKeys, key)
 		}
 	}

--- a/v2/pkg/utils/predicates/predicates_suite_test.go
+++ b/v2/pkg/utils/predicates/predicates_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2021 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicates Suite")
+}

--- a/v2/pkg/utils/predicates/predicates_test.go
+++ b/v2/pkg/utils/predicates/predicates_test.go
@@ -1,0 +1,72 @@
+// Copyright 2021 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicates
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Predicate tests", func() {
+	Context("SyncedMapHandler", func() {
+		var (
+			sut              *SyncedMapHandler
+			obj1, obj2, obj3 types.NamespacedName
+			mapObj           handler.MapObject
+			result           reconcile.Request
+		)
+
+		BeforeEach(func() {
+			sut = NewSyncedMapHandler(func(in types.NamespacedName) bool {
+				return false
+			})
+			obj1 = types.NamespacedName{Name: "foo", Namespace: "foons"}
+			obj2 = types.NamespacedName{Name: "bar", Namespace: "foons"}
+			obj3 = types.NamespacedName{Name: "baz", Namespace: "foons"}
+			mapObj.Meta = &v1.ObjectMeta{Name: "foo", Namespace: "foons"}
+			result.NamespacedName = obj2
+
+			sut.AddOrUpdate(obj1, obj2)
+		})
+
+		It("should map to nothing if no obj provided", func() {
+			results := sut.Map(handler.MapObject{})
+			Expect(results, HaveLen(0))
+		})
+
+		It("should map to nothing if no obj provided", func() {
+			results := sut.Map(mapObj)
+			Expect(results, HaveLen(1))
+			Expect(results[0], Equal(result))
+		})
+
+		It("should add", func() {
+			sut.AddOrUpdate(obj3, obj2)
+			results := sut.Map(mapObj)
+			Expect(results, HaveLen(1))
+			Expect(results[0], Equal(result))
+		})
+
+		It("should cleanup", func() {
+			sut.Cleanup()
+			results := sut.Map(mapObj)
+			Expect(results, HaveLen(0))
+		})
+	})
+})

--- a/v2/tests/metadata/golden/role.yaml
+++ b/v2/tests/metadata/golden/role.yaml
@@ -5,253 +5,254 @@ kind: ClusterRole
 metadata:
   name: redhat-marketplace-operator
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resourceNames:
-  - razeedeploy-admin-cr
-  - redhat-marketplace-razeedeploy
-  resources:
-  - clusterroles
-  verbs:
-  - get
-  - list
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - persistentvolumes
-  - events
-  - configmaps
-  - secrets
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - update
-- apiGroups:
-  - batch
-  - extensions
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  - replicasets
-  - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resourceNames:
-  - redhat-marketplace-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheuses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  - clusterserviceversions
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-  - delete
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - operatorsources
-  - catalogsources
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-- apiGroups:
-  - operators.coreos.com
-  resourceNames:
-  - redhat-marketplace
-  resources:
-  - operatorsources
-  verbs:
-  - get
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - operators.coreos.com
-  resourceNames:
-  - ibm-operator-catalog
-  - opencloud-operators
-  resources:
-  - catalogsources
-  verbs:
-  - get
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - operatorgroups
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - deploy.razee.io
-  resources:
-  - remoteresourcess3
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - consoles
-  - infrastructures
-  - clusterversions
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-- apiGroups:
-  - marketplace.redhat.com
-  resources:
-  - '*'
-  - meterdefinitions
-  - razeedeployments
-  - meterbases
-  - marketplaceconfigs
-  - remoteresources3s
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resourceNames:
-  - rhm-cos-reader-key
-  - watch-keeper-secret
-  resources:
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resourceNames:
-  - watch-keeper-config
-  - watch-keeper-limit-poll
-  - watch-keeper-non-namespaced
-  - razee-cluster-metadata
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- nonResourceURLs:
-  - /api/v1/query
-  - /api/v1/query_range
-  verbs:
-  - get
-  - create
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - razeedeploy-admin-cr
+      - redhat-marketplace-razeedeploy
+    resources:
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - persistentvolumes
+      - events
+      - configmaps
+      - secrets
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - batch
+      - extensions
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - replicasets
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - redhat-marketplace-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheuses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operatorsources
+      - catalogsources
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - operators.coreos.com
+    resourceNames:
+      - redhat-marketplace
+    resources:
+      - operatorsources
+    verbs:
+      - get
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - operators.coreos.com
+    resourceNames:
+      - ibm-operator-catalog
+      - opencloud-operators
+    resources:
+      - catalogsources
+    verbs:
+      - get
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operatorgroups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - deploy.razee.io
+    resources:
+      - remoteresourcess3
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - consoles
+      - infrastructures
+      - clusterversions
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+  - apiGroups:
+      - marketplace.redhat.com
+    resources:
+      - '*'
+      - meterdefinitions
+      - razeedeployments
+      - meterbases
+      - marketplaceconfigs
+      - remoteresources3s
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resourceNames:
+      - rhm-cos-reader-key
+      - watch-keeper-secret
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resourceNames:
+      - watch-keeper-config
+      - watch-keeper-limit-poll
+      - watch-keeper-non-namespaced
+      - razee-cluster-metadata
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - nonResourceURLs:
+      - /api/v1/query
+      - /api/v1/query_range
+      - /api/v1/targets
+    verbs:
+      - get
+      - create
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -259,19 +260,19 @@ kind: ClusterRole
 metadata:
   name: redhat-marketplace-remoteresources3deployment
 rules:
-- apiGroups:
-  - operators.coreos.com
-  - marketplace.redhat.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - operators.coreos.com
+      - marketplace.redhat.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -279,84 +280,84 @@ kind: ClusterRole
 metadata:
   name: redhat-marketplace-prometheus-operator
 rules:
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - create
-- apiGroups:
-  - apiextensions.k8s.io
-  resourceNames:
-  - alertmanagers.monitoring.coreos.com
-  - podmonitors.monitoring.coreos.com
-  - prometheuses.monitoring.coreos.com
-  - prometheusrules.monitoring.coreos.com
-  - servicemonitors.monitoring.coreos.com
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - alertmanagers
-  - prometheuses
-  - prometheuses/finalizers
-  - alertmanagers/finalizers
-  - servicemonitors
-  - podmonitors
-  - prometheusrules
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - services/finalizers
-  - endpoints
-  verbs:
-  - get
-  - create
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - alertmanagers.monitoring.coreos.com
+      - podmonitors.monitoring.coreos.com
+      - prometheuses.monitoring.coreos.com
+      - prometheusrules.monitoring.coreos.com
+      - servicemonitors.monitoring.coreos.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheuses/finalizers
+      - alertmanagers/finalizers
+      - servicemonitors
+      - podmonitors
+      - prometheusrules
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - services/finalizers
+      - endpoints
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -364,54 +365,54 @@ kind: ClusterRole
 metadata:
   name: redhat-marketplace-prometheus
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes/metrics
-  verbs:
-  - get
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes/metrics
+    verbs:
+      - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -419,20 +420,20 @@ kind: ClusterRole
 metadata:
   name: redhat-marketplace-watch-keeper
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -441,12 +442,12 @@ metadata:
   name: redhat-marketplace-remoteresources3deployment
   namespace: openshift-redhat-marketplace
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -455,12 +456,12 @@ metadata:
   name: redhat-marketplace-prometheus
   namespace: openshift-redhat-marketplace
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -469,16 +470,16 @@ metadata:
   name: redhat-marketplace-reporter
   namespace: openshift-config
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - pull-secret
-  resources:
-  - secrets
-  verbs:
-  - get
-  - watch
-  - list
+  - apiGroups:
+      - ''
+    resourceNames:
+      - pull-secret
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -487,112 +488,112 @@ metadata:
   name: redhat-marketplace-operator
   namespace: openshift-redhat-marketplace
 rules:
-- apiGroups:
-  - deploy.razee.io
-  resources:
-  - '*'
-  - remoteresourcess3
-  - remoteresources
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - watch
-  - update
-- apiGroups:
-  - batch
-  - extensions
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resourceNames:
-  - redhat-marketplace-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resourceNames:
-  - razeedeploy-sa
-  - watch-keeper-sa
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - patch
-  - watch
+  - apiGroups:
+      - deploy.razee.io
+    resources:
+      - '*'
+      - remoteresourcess3
+      - remoteresources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - patch
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - subscriptions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - watch
+      - update
+  - apiGroups:
+      - batch
+      - extensions
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - redhat-marketplace-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resourceNames:
+      - razeedeploy-sa
+      - watch-keeper-sa
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - patch
+      - watch


### PR DESCRIPTION
Secrets and service monitors started to have issues back when the UWM feature was first created. So the project transitioned from using a static one, to creating one based on the current token, to just trying to use the same secret on the operator pod. This last method broke with 4.8. This PR looks to address that.

This solution generates a token but makes sure to generate a uniquely named one, and the secret is tied to the pod of the operator. So if the pod is deleted, this secret will be cleaned up and on reinstall a new one. This prevents an issue that can occur when the secret is no longer valid.

What it does:
- Generate a new secret in the openshift-redhat-marketplace ns
- If the secret is deleted, it will get recreate automatically.
- If the pod is deleted, it'll delete the secret.
- Service monitors use the secret as the token value.