### PR TITLE
WIP Feature/cert pipeline

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -2,6 +2,7 @@
 VERSION ?= $(shell cd ./tools/version && go run ./main.go)
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
+OPENSHIFT_VERSIONS ?= v4.6-v4.9
 
 export VERSION
 
@@ -172,6 +173,7 @@ docker-manifest:
 	docker manifest push $(IMAGE)
 
 CSV_YAML_BUNDLE_FILE=bundle/manifests/redhat-marketplace-operator.clusterserviceversion.yaml
+ANNOTATIONS_YAML_BUNDLE_FILE=bundle/metadata/annotations.yaml
 CREATED_TIME ?= $(shell date +"%FT%H:%M:%SZ")
 
 # Generate bundle manifests and metadata, then validate generated files.
@@ -184,7 +186,9 @@ bundle: clean manifests kustomize helm operator-sdk yq
 	--set reporterImage=$(REPORTER_IMAGE) \
 	--set authCheckImage=$(AUTHCHECK_IMAGE) \
 	--set dqLiteImage=$(DQLITE_IMAGE) \
+	--set serviceAccount.create=false \
 	--post-renderer ./config/manifests/kustomize | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(YQ) eval -i '.annotations."com.redhat.openshift.versions" = "$(OPENSHIFT_VERSIONS)"' $(ANNOTATIONS_YAML_BUNDLE_FILE)
 	$(YQ) eval -i '.spec.webhookdefinitions[].targetPort = 9443' $(CSV_YAML_BUNDLE_FILE)
 	$(YQ) eval -i '.spec.webhookdefinitions[].containerPort = 9443' $(CSV_YAML_BUNDLE_FILE)
 	$(YQ) eval -i ".metadata.annotations.containerImage = \"$(OPERATOR_IMAGE)\"" $(CSV_YAML_BUNDLE_FILE)

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -331,7 +331,16 @@ wait-and-publish:
 	cd tools/connect ; \
 	go run main.go wait-and-publish --timeout $(TIMEOUT) --tag $(TAG) $(PIDS)
 
+# Pin images in bundle
+.PHONY: bundle-pin-images
+bundle-pin-images:
+	docker run \
+	--pull always \
+	-v ${HOME}/.docker:/dockercfg \
+	-v $(shell pwd)/bundle/manifests:/manifests quay.io/operator-framework/operator-manifest-tools:latest \
+	pinning pin -a /dockercfg/config.json /manifests
+
 # Run certification test
 .PHONY: test-certify
-test-certify: bundle
+test-certify: bundle bundle-pin-images
 	cd hack/certify && ./certify.sh

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -186,7 +186,6 @@ bundle: clean manifests kustomize helm operator-sdk yq
 	--set reporterImage=$(REPORTER_IMAGE) \
 	--set authCheckImage=$(AUTHCHECK_IMAGE) \
 	--set dqLiteImage=$(DQLITE_IMAGE) \
-	--set serviceAccount.create=false \
 	--post-renderer ./config/manifests/kustomize | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(YQ) eval -i '.annotations."com.redhat.openshift.versions" = "$(OPENSHIFT_VERSIONS)"' $(ANNOTATIONS_YAML_BUNDLE_FILE)
 	$(YQ) eval -i '.spec.webhookdefinitions[].targetPort = 9443' $(CSV_YAML_BUNDLE_FILE)

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -3,6 +3,8 @@ VERSION ?= $(shell cd ./tools/version && go run ./main.go)
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
 OPENSHIFT_VERSIONS ?= v4.6-v4.9
+CHANNELS ?= beta,stable
+DEFAULT_CHANNEL ?= stable
 
 export VERSION
 
@@ -328,3 +330,8 @@ PIDs ?=
 wait-and-publish:
 	cd tools/connect ; \
 	go run main.go wait-and-publish --timeout $(TIMEOUT) --tag $(TAG) $(PIDS)
+
+# Run certification test
+.PHONY: test-certify
+test-certify: bundle
+	cd hack/certify && ./certify.sh

--- a/v2/hack/certify/certify.sh
+++ b/v2/hack/certify/certify.sh
@@ -6,6 +6,9 @@ SLEEP_SHORT="${SLEEP_SHORT:-2}"
 CERT_NAMESPACE="rhm-certification"
 KUBECONFIG=$HOME/.kube/config
 VERSION="2.4.0"
+IMAGE_REGISTRY=quay.io/dacleyra
+CHANNELS=beta,stable
+DEFAULT_CHANNEL=stable
 
 # Check Subscriptions: subscription-name, namespace
 checksub () {
@@ -117,6 +120,8 @@ oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/pipelines
 oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/tasks
 cd $CWD
 
+oc apply -f https://raw.githubusercontent.com/tonytcampbell/operator-pipelines/preflight-fixes/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+
 
 # Generate the bundle and add it to the fork
 cd $TMP_DIR
@@ -136,12 +141,6 @@ rm -Rf  $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operat
 
 echo "organization: redhat-marketplace" > $TMP_DIR/certified-operators-preprod/config.yaml
 echo "cert_project_id: 5f68c9457115dbd1183ccab6" > $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/ci.yaml
-
-cd $TMP_DIR
-curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64.tar.gz | tar -xz 
-./yq_linux_amd64 eval '
-  .annotations."com.redhat.openshift.versions" = "v4.6-v4.9"
-' -i $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/metadata/annotations.yaml
 
 cd $TMP_DIR/certified-operators-preprod
 git add --all

--- a/v2/hack/certify/certify.sh
+++ b/v2/hack/certify/certify.sh
@@ -125,7 +125,7 @@ echo "cert_project_id: 5ec3fc8628834587a6b85c2a" > $TMP_DIR/certified-operators-
 cd $TMP_DIR
 curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64.tar.gz | tar -xz 
 ./yq_linux_amd64 eval '
-  .metadata.annotations."com.redhat.openshift.versions" = "v4.6-v4.9"
+  .annotations."com.redhat.openshift.versions" = "v4.6-v4.9"
 ' -i $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/metadata/annotations.yaml
 
 cd $TMP_DIR/certified-operators-preprod

--- a/v2/hack/certify/certify.sh
+++ b/v2/hack/certify/certify.sh
@@ -3,12 +3,8 @@ set -Eeox pipefail
 
 SLEEP_LONG="${SLEEP_LONG:-5}"
 SLEEP_SHORT="${SLEEP_SHORT:-2}"
-CERT_NAMESPACE="rhm-certification"
-KUBECONFIG=$HOME/.kube/config
-VERSION="2.4.0"
-IMAGE_REGISTRY=quay.io/dacleyra
-CHANNELS=beta,stable
-DEFAULT_CHANNEL=stable
+CERT_NAMESPACE="${CERT_NAMESPACE:-rhm-certification}"
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 
 # Check Subscriptions: subscription-name, namespace
 checksub () {
@@ -123,20 +119,22 @@ cd $CWD
 oc apply -f https://raw.githubusercontent.com/tonytcampbell/operator-pipelines/preflight-fixes/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
 
 
-# Generate the bundle and add it to the fork
+# Add bundle to the fork
 cd $TMP_DIR
 git clone git@github.com:redhat-marketplace/certified-operators-preprod.git
 
 cd $CWD
 cd ../../
 
-make bundle
 rm -rf $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION
 mkdir -p $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION
 cp -r bundle/manifests $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/
 cp -r bundle/metadata $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/
 
-# remove sa duplicated in csv?
+# The operator service account should be ommited in the bundle
+# It will fail certification
+# The service account will be created by OLM
+# kustomize questionable capability to remove the service account
 rm -Rf  $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/manifests/redhat-marketplace-operator_v1_serviceaccount.yaml
 
 echo "organization: redhat-marketplace" > $TMP_DIR/certified-operators-preprod/config.yaml

--- a/v2/hack/certify/certify.sh
+++ b/v2/hack/certify/certify.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -Eeox pipefail
+
+SLEEP_LONG="${SLEEP_LONG:-5}"
+SLEEP_SHORT="${SLEEP_SHORT:-2}"
+CERT_NAMESPACE="rhm-certification"
+KUBECONFIG=$HOME/.kube/config
+VERSION="2.4.0"
+
+# Check Subscriptions: subscription-name, namespace
+checksub () {
+	echo "Waiting for Subscription $1 InstallPlan to complete."
+
+	# Wait 2 resync periods for OLM to emit new installplan
+	sleep 60
+
+	# Wait for the InstallPlan to be generated and available on status
+	unset INSTALL_PLAN
+	until oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name}
+	do
+		sleep $SLEEP_SHORT
+	done
+
+	# Get the InstallPlan
+	until [ -n "$INSTALL_PLAN" ]
+	do
+		sleep $SLEEP_SHORT
+		INSTALL_PLAN=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installPlanRef.name})
+	done
+
+	# Wait for the InstallPlan to Complete
+	unset PHASE
+	until [ "$PHASE" == "Complete" ]
+	do
+		PHASE=$(oc get installplan $INSTALL_PLAN -n $2 --output=jsonpath={.status.phase})
+    if [ "$PHASE" == "Failed" ]; then
+      set +x
+      sleep 3
+      echo "InstallPlan $INSTALL_PLAN for subscription $1 failed."
+      echo "To investigate the reason of the InstallPlan failure run:"
+      echo "oc describe installplan $INSTALL_PLAN -n $2"
+      exit 1
+    fi
+		sleep $SLEEP_SHORT
+	done
+	
+	# Get installed CluserServiceVersion
+	unset CSV
+	until [ -n "$CSV" ]
+	do
+		sleep $SLEEP_SHORT
+		CSV=$(oc get subscription $1 -n $2 --output=jsonpath={.status.installedCSV})
+	done
+	
+	# Wait for the CSV
+	unset PHASE
+	until [ "$PHASE" == "Succeeded" ]
+	do
+		PHASE=$(oc get clusterserviceversion $CSV -n $2 --output=jsonpath={.status.phase})
+    if [ "$PHASE" == "Failed" ]; then
+      set +x
+      sleep 3
+      echo "ClusterServiceVersion $CSV for subscription $1 failed."
+      echo "To investigate the reason of the ClusterServiceVersion failure run:"
+      echo "oc describe clusterserviceversion $CSV -n $2"
+      exit 1
+    fi
+		sleep $SLEEP_SHORT
+	done
+}
+
+
+
+# Install Subscription
+oc apply -f sub.yaml
+
+# Verify Subscriptions
+checksub openshift-pipelines-operator-rh openshift-operators
+
+# Switch to certification namespace
+oc delete ns $CERT_NAMESPACE --ignore-not-found
+oc adm new-project $CERT_NAMESPACE
+oc project $CERT_NAMESPACE
+
+# Create the kubeconfig used by the certification pipeline
+oc delete secret kubeconfig --ignore-not-found
+oc create secret generic kubeconfig --from-file=kubeconfig=$KUBECONFIG
+
+# Import redhat catalogs
+oc import-image redhat-marketplace-index \
+  --from=registry.redhat.io/redhat/redhat-marketplace-index \
+  --reference-policy local \
+  --scheduled \
+  --confirm \
+  --all
+
+CWD=$(pwd)
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'cptmpdir')
+
+# Install the Certification Pipeline
+cd $TMP_DIR
+git clone https://github.com/redhat-openshift-ecosystem/operator-pipelines
+cd operator-pipelines
+oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/pipelines
+oc apply -R -f ansible/roles/operator-pipeline/templates/openshift/tasks
+cd $CWD
+
+
+# Generate the bundle and add it to the fork
+cd $TMP_DIR
+git clone git@github.com:redhat-marketplace/certified-operators-preprod.git
+
+cd $CWD
+cd ../../
+
+make bundle
+rm -rf $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION
+mkdir -p $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION
+cp -r bundle/manifests $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/
+cp -r bundle/metadata $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/
+
+echo "organization: redhat-marketplace" > $TMP_DIR/certified-operators-preprod/config.yaml
+echo "cert_project_id: 5ec3fc8628834587a6b85c2a" > $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/ci.yaml
+
+cd $TMP_DIR
+curl -L https://github.com/mikefarah/yq/releases/download/v4.13.5/yq_linux_amd64.tar.gz | tar -xz 
+./yq_linux_amd64 eval '
+  .metadata.annotations."com.redhat.openshift.versions" = "v4.6-v4.9"
+' -i $TMP_DIR/certified-operators-preprod/operators/redhat-marketplace-operator/$VERSION/metadata/annotations.yaml
+
+cd $TMP_DIR/certified-operators-preprod
+git add --all
+git commit -m $VERSION
+git push
+
+
+# Run the Pipeline
+
+cd $TMP_DIR/operator-pipelines
+curl https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.19.1/tkn-linux-amd64-0.19.1.tar.gz | tar -xz 
+
+GIT_REPO_URL=https://github.com/redhat-marketplace/certified-operators-preprod.git
+BUNDLE_PATH=operators/redhat-marketplace-operator/$VERSION
+
+./tkn pipeline start operator-ci-pipeline \
+  --param git_repo_url=$GIT_REPO_URL \
+  --param git_branch=stage \
+  --param bundle_path=$BUNDLE_PATH \
+  --param env=stage \
+  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
+  --workspace name=kubeconfig,secret=kubeconfig \
+  --showlog

--- a/v2/hack/certify/sub.yaml
+++ b/v2/hack/certify/sub.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator-rh
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
To pass certification checks
- annotations.yaml needs
  - openshift.versions
	- CHANNELS, DEFAULT_CHANNELS with default; must be set to generate their required associated annotations
- remove the operator service account yaml, this should be created by OLM & fails a cert check
  - didn't seem to be a great way to remove it via a kustomize option; make bundle vs. make install needing the sa