### PR TITLE
bugfix: fix rrs3 reconcilation

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -56,7 +56,7 @@ IMG ?= $(OPERATOR_IMAGE)
 IMAGE ?= $(OPERATOR_IMAGE)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 # CRD_OPTIONS ?= "crd:trivialVersions=true"
-CRD_OPTIONS ?= "crd:crdVersions={v1},trivialVersions=false,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd:crdVersions={v1}"
 
 GOPATH=$(shell go env GOPATH)
 

--- a/v2/apis/marketplace/v1alpha1/remoteresources3_types.go
+++ b/v2/apis/marketplace/v1alpha1/remoteresources3_types.go
@@ -145,6 +145,7 @@ type Header map[string]string
 
 // RemoteResourceS3Spec defines the desired state of RemoteResourceS3
 // +k8s:openapi-gen=true
+// +kubebuilder:pruning:PreserveUnknownFields
 type RemoteResourceS3Spec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	// Auth provides options to authenticate to a remote location

--- a/v2/assets/prometheus-operator/deployment-v4.5.yaml
+++ b/v2/assets/prometheus-operator/deployment-v4.5.yaml
@@ -26,13 +26,13 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64
-                    - ppc64le
-                    - s390x    
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
       containers:
         - image: redhat-marketplace-authcheck:latest
           imagePullPolicy: IfNotPresent
@@ -43,13 +43,13 @@ spec:
               memory: 20Mi
             limits:
               cpu: 10m
-              memory: 25Mi              
+              memory: 25Mi
           terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             privileged: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
@@ -76,15 +76,15 @@ spec:
               memory: 60Mi
             limits:
               cpu: 10m
-              memory: 60Mi              
+              memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true 
+            runAsNonRoot: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private
@@ -109,15 +109,15 @@ spec:
               memory: 40Mi
             limits:
               cpu: 1m
-              memory: 40Mi           
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-              - ALL
+                - ALL
             privileged: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true 
+            runAsNonRoot: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /etc/tls/private

--- a/v2/assets/prometheus-operator/deployment-v4.6.yaml
+++ b/v2/assets/prometheus-operator/deployment-v4.6.yaml
@@ -71,7 +71,7 @@ spec:
               memory: 60Mi
             limits:
               cpu: 10m
-              memory: 60Mi
+              memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/assets/razee/rrs3-controller-deployment.yaml
+++ b/v2/assets/razee/rrs3-controller-deployment.yaml
@@ -91,14 +91,18 @@ spec:
               memory: 75Mi
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-            - mountPath: /usr/src/app/download-cache
+            - mountPath: /home/node/download-cache
               name: cache-volume
+            - mountPath: /usr/src/app/download-cache
+              name: cache-volume-2
             - mountPath: /usr/src/app/config
               name: razeedeploy-config
       serviceAccountName: redhat-marketplace-remoteresources3deployment
       volumes:
         - emptyDir: {}
           name: cache-volume
+        - emptyDir: {}
+          name: cache-volume-2
         - configMap:
             defaultMode: 440
             name: razeedeploy-config

--- a/v2/config/crd/bases/marketplace.redhat.com_marketplaceconfigs.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_marketplaceconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: marketplaceconfigs.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterbases.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterbases.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: meterbases.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterdefinitions.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: meterdefinitions.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_meterreports.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_meterreports.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: meterreports.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_razeedeployments.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_razeedeployments.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: razeedeployments.marketplace.redhat.com
 spec:

--- a/v2/config/crd/bases/marketplace.redhat.com_remoteresources3s.yaml
+++ b/v2/config/crd/bases/marketplace.redhat.com_remoteresources3s.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: remoteresources3s.marketplace.redhat.com
 spec:
@@ -209,6 +209,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: RemoteResourceS3Status defines the observed state of RemoteResourceS3
             properties:

--- a/v2/config/crd/patches/remotes3_disable_preserve_unknown_fields.yaml
+++ b/v2/config/crd/patches/remotes3_disable_preserve_unknown_fields.yaml
@@ -1,6 +1,0 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: remoteresources3s.marketplace.redhat.com
-spec:
-  preserveUnknownFields: true

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -12,30 +12,6 @@ rules:
       - '*'
     verbs:
       - '*'
-  - apiGroups:
-      - ''
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - update
-    resourceNames:
-      - meterdefinitions.marketplace.redhat.com
-  - apiGroups:
-      - 'route.openshift.io'
-    resources:
-      - routes
-    verbs:
-      - get
-      - list
-      - watch
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -231,6 +207,7 @@ rules:
     resources:
       - secrets
     verbs:
+      - get
       - list
       - watch
 ---

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -15,6 +15,7 @@
 package marketplace
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
@@ -911,7 +912,7 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 			return reconcile.Result{}, err
 		}
 
-		if !reflect.DeepEqual(watchKeeperSecret.Data, updatedWatchKeeperSecret.Data) {
+		if !isMapStringByteEqual(watchKeeperSecret.Data, updatedWatchKeeperSecret.Data) {
 			err = r.Client.Update(context.TODO(), &watchKeeperSecret)
 			if err != nil {
 				reqLogger.Error(err, "Failed to create resource", "resource: ", utils.WATCH_KEEPER_SECRET_NAME)
@@ -981,13 +982,13 @@ func (r *RazeeDeploymentReconciler) Reconcile(request reconcile.Request) (reconc
 			return reconcile.Result{}, err
 		}
 
-		if !reflect.DeepEqual(ibmCosReaderKey.Data, updatedibmCosReaderKey.Data) {
+		if !isMapStringByteEqual(ibmCosReaderKey.Data, updatedibmCosReaderKey.Data) {
 			err = r.Client.Update(context.TODO(), &ibmCosReaderKey)
 			if err != nil {
-				reqLogger.Error(err, "Failed to create resource", "resource: ", utils.WATCH_KEEPER_SECRET_NAME)
+				reqLogger.Error(err, "Failed to create resource", "resource: ", utils.COS_READER_KEY_NAME)
 				return reconcile.Result{}, err
 			}
-			reqLogger.Info("Resource updated successfully", "resource: ", utils.WATCH_KEEPER_SECRET_NAME)
+			reqLogger.Info("Resource updated successfully", "resource: ", utils.COS_READER_KEY_NAME)
 			return reconcile.Result{Requeue: true}, nil
 		}
 
@@ -1947,4 +1948,27 @@ func (r *RazeeDeploymentReconciler) createOrUpdateWatchKeeperDeployment(
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func isMapStringByteEqual(d1, d2 map[string][]byte) bool {
+	equal := true
+	for key2, value2 := range d1 {
+		found := false
+		for key, value := range d2 {
+			if key == key2 {
+				found = true
+				if bytes.Compare(value, value2) != 0 {
+					equal = false
+					break
+				}
+			}
+		}
+
+		if !found {
+			equal = false
+			break
+		}
+	}
+
+	return equal
 }

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -151,8 +151,8 @@ func (f *Factory) ReplaceImages(container *corev1.Container) error {
 					Port: intstr.FromInt(8089),
 				},
 			},
-			InitialDelaySeconds: 15,
-			PeriodSeconds:       20,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       30,
 		}
 		container.ReadinessProbe = &corev1.Probe{
 			Handler: corev1.Handler{
@@ -161,8 +161,8 @@ func (f *Factory) ReplaceImages(container *corev1.Container) error {
 					Port: intstr.FromInt(8089),
 				},
 			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       10,
+			InitialDelaySeconds: 20,
+			PeriodSeconds:       30,
 		}
 
 		envChanges.Append(addPodName)
@@ -179,13 +179,17 @@ func (f *Factory) ReplaceImages(container *corev1.Container) error {
 
 		// watch-keeper and rrs3 doesn't use HTTPS_PROXY correctly
 		// will fail; HTTP_PROXY will be used instead
-		envChanges.Append(removeHTTPSProxy)
+		envChanges.Remove(corev1.EnvVar{
+			Name: "HTTPS_PROXY",
+		})
 	case container.Name == "watch-keeper":
 		container.Image = f.config.RelatedImages.WatchKeeper
 
 		// watch-keeper and rrs3 doesn't use HTTPS_PROXY correctly
 		// will fail; HTTP_PROXY will be used instead
-		envChanges.Append(removeHTTPSProxy)
+		envChanges.Remove(corev1.EnvVar{
+			Name: "HTTPS_PROXY",
+		})
 	}
 
 	envChanges.Merge(container)
@@ -193,14 +197,6 @@ func (f *Factory) ReplaceImages(container *corev1.Container) error {
 }
 
 var (
-	removeHTTPSProxy = envvar.Changes{
-		envvar.Add(
-			corev1.EnvVar{
-				Name:  "HTTPS_PROXY",
-				Value: "",
-			},
-		),
-	}
 	addPodName = envvar.Changes{
 		envvar.Add(corev1.EnvVar{
 			Name: "POD_NAME",

--- a/v2/pkg/utils/envvar/envvar_test.go
+++ b/v2/pkg/utils/envvar/envvar_test.go
@@ -24,8 +24,10 @@ import (
 
 var _ = Describe("envvar", func() {
 	var (
-		var1 = v1.EnvVar{Name: "foo"}
-		var2 = v1.EnvVar{Name: "foo2"}
+		var1  = v1.EnvVar{Name: "foo"}
+		var2  = v1.EnvVar{Name: "foo2"}
+		var2a = v1.EnvVar{Name: "foo2", Value: "a"}
+		var2b = v1.EnvVar{Name: "foo2", Value: "b"}
 
 		container corev1.Container
 		changes   envvar.Changes
@@ -48,6 +50,13 @@ var _ = Describe("envvar", func() {
 		changes.Remove(var1)
 		changes.Merge(&container)
 		Expect(container.Env).To(BeEmpty())
+	})
+
+	It("should override if same name", func() {
+		changes.Add(var2a)
+		changes.Add(var2b)
+		changes.Merge(&container)
+		Expect(container.Env).To(ConsistOf(var1, var2b))
 	})
 
 	It("should add/remove env vars", func() {


### PR DESCRIPTION
Changes
- Add unknown-fields attribute to RRS3 spec (required for v1 to work)
- Patches RRS3 deployment asset yaml to fix pathing issues with startup
- Patches razeedeployment controller to get past equality checks on secret data (infinite loop, yay)
- Removes HTTPS_PROXY being set to "" on RRS3 and watchkeeper.
- Resets permissions to 2.3.4
- Bumps limits on Prometheus Operator to prevent OOM