### PR TITLE
various fixes

### DIFF
--- a/metering/v2/pkg/dictionary/cache.go
+++ b/metering/v2/pkg/dictionary/cache.go
@@ -45,7 +45,6 @@ func init() {
 		lookupCache = utils.Must(func() (interface{}, error) {
 			limit, _ := strconv.Atoi(os.Getenv("MEMORY_LIMIT"))
 			limit = int(float64(limit) * pct)
-			fmt.Println(fmt.Sprintf("dac debug memory limit %v", limit))
 			cache, err := bigcache.NewBigCache(bigcache.Config{
 				Shards:             1024,
 				LifeWindow:         cacheTimeout,

--- a/tests/v2/e2e/userworkloadmonitoring-test/01-uwm-config.yaml
+++ b/tests/v2/e2e/userworkloadmonitoring-test/01-uwm-config.yaml
@@ -6,12 +6,12 @@ data:
         requests:
           cpu: 70m
           memory: 1Gi
-      retention: 24h
+      retention: 168h
       volumeClaimTemplate:
         spec:
           resources:
             requests:
-              storage: 20Gi
+              storage: 40Gi
 kind: ConfigMap
 metadata:
   name: user-workload-monitoring-config

--- a/tests/v2/e2e/userworkloadmonitoring-test/21-uwm-config.yaml
+++ b/tests/v2/e2e/userworkloadmonitoring-test/21-uwm-config.yaml
@@ -6,12 +6,12 @@ data:
         requests:
           cpu: 70m
           memory: 1Gi
-      retention: 24h
+      retention: 168h
       volumeClaimTemplate:
         spec:
           resources:
             requests:
-              storage: 20Gi
+              storage: 40Gi
 kind: ConfigMap
 metadata:
   name: user-workload-monitoring-config

--- a/tests/v2/e2e/userworkloadmonitoring-test/41-uwm-config.yaml
+++ b/tests/v2/e2e/userworkloadmonitoring-test/41-uwm-config.yaml
@@ -6,12 +6,12 @@ data:
         requests:
           cpu: 70m
           memory: 1Gi
-      retention: 24h
+      retention: 168h
       volumeClaimTemplate:
         spec:
           resources:
             requests:
-              storage: 20Gi
+              storage: 40Gi
 kind: ConfigMap
 metadata:
   name: user-workload-monitoring-config

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -2,6 +2,9 @@ comma := ,
 space :=
 space +=
 
+UNAME_S := $(shell uname -s)
+UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
+
 VERSION ?= $(shell $(SVU) next --prefix "")
 TAG ?= $(VERSION)
 
@@ -134,8 +137,11 @@ pc-tool:
 
 BUF=$(PROJECT_DIR)/bin/buf
 BUF_VERSION=v1.0.0-rc8
+ifeq ($(UNAME_S),Linux)
+WILDCARDS=--wildcards
+endif
 buf:
-	$(call install-targz,https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(shell uname -s)-$(shell uname -m).tar.gz,$(BUF),$(BUF_VERSION),$(PROJECT_DIR)/bin,--strip-components 2 --wildcards "*/bin/*")
+	$(call install-targz,https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(shell uname -s)-$(shell uname -m).tar.gz,$(BUF),$(BUF_VERSION),$(PROJECT_DIR)/bin,--strip-components 2 $(WILDCARDS) "*/bin/*")
 
 # --COMMON--
 

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -135,7 +135,7 @@ pc-tool:
 BUF=$(PROJECT_DIR)/bin/buf
 BUF_VERSION=v1.0.0-rc8
 buf:
-	$(call install-targz,https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(shell uname -s)-$(shell uname -m).tar.gz,$(BUF),$(BUF_VERSION),$(PROJECT_DIR)/bin,--strip-components 2 "*/bin/*")
+	$(call install-targz,https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(shell uname -s)-$(shell uname -m).tar.gz,$(BUF),$(BUF_VERSION),$(PROJECT_DIR)/bin,--strip-components 2 --wildcards "*/bin/*")
 
 # --COMMON--
 

--- a/v2/controllers/marketplace/meterdefinition_controller.go
+++ b/v2/controllers/marketplace/meterdefinition_controller.go
@@ -446,7 +446,14 @@ func (r *MeterDefinitionReconciler) verifyReporting(cc ClientCommandRunner, inst
 	reqLogger.Info("getting meter_def_name labelvalues from prometheus")
 
 	mdefLabelValue := model.LabelValue(instance.Name)
-	matches := []string{string(mdefLabelValue)}
+
+	// prometheus/client_golang v1.10.0 modified the api to add matches
+	// https://github.com/prometheus/client_golang/pull/828
+	// controller-util currently requires client_golang v1.11.0
+	// use of matches in our use case results in an error "bad_data: 1:4: parse error: unexpected <op:->"
+
+	//matches := []string{string(mdefLabelValue)}
+	matches := []string{}
 
 	labelValues, warnings, err := prometheusAPI.MeterDefLabelValues(matches)
 

--- a/v2/hack/certify/sub.yaml
+++ b/v2/hack/certify/sub.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-redhat-marketplace
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:


### PR DESCRIPTION
remove debug statement in cache.go
update e2e uwm test config to minimum required values
add a set UNAME_S to utils.Makefile
add --wildcards flag to tar extract for buf for linux
remove use of matches in prometheusAPI.MeterDefLabelValues due to error
unsure why error occurs, could be a bug, could be due to thanos target, and it doesn't support matches?
update certification script with submit check, required secret creation, and create namespace for webhook/finalizer workaround