### PR TITLE
fix: fix local execution of report tool

### DIFF
--- a/reporter/v2/pkg/reporter/wire_gen.go
+++ b/reporter/v2/pkg/reporter/wire_gen.go
@@ -80,7 +80,7 @@ func NewReporter(ctx context.Context, task *Task) (*MarketplaceReporter, error) 
 	if err != nil {
 		return nil, err
 	}
-	service, err := getPrometheusService(ctx, meterReport, clientCommandRunner, config)
+	service, err := getPrometheusService(ctx, clientCommandRunner, config)
 	if err != nil {
 		return nil, err
 	}

--- a/reporter/v2/pkg/uploaders/localfile.go
+++ b/reporter/v2/pkg/uploaders/localfile.go
@@ -40,7 +40,7 @@ func (r *LocalFilePathUploader) UploadFile(ctx context.Context, file string, rea
 	fileName := filepath.Join(r.LocalFilePath, baseName)
 
 	log.Info("creating file", "name", fileName)
-	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(fileName, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Error(err, "Error creating", "name", fileName)
 		return "", err

--- a/v2/apis/marketplace/common/prometheus.go
+++ b/v2/apis/marketplace/common/prometheus.go
@@ -196,7 +196,7 @@ func (m *MeterDefPrometheusLabels) PrintTemplate(
 			t2, err2 := time.Parse(justDateFormat, result.DateLabelOverride)
 
 			if err2 != nil {
-				return nil, errors.Combine(err, err2)
+				return nil, errors.Errorf("failed to parse overrideDate value %q", result.DateLabelOverride)
 			}
 
 			t = t2

--- a/v2/pkg/prometheus/prometheus_client.go
+++ b/v2/pkg/prometheus/prometheus_client.go
@@ -125,12 +125,6 @@ func providePrometheusAPI(
 func providePrometheusAPIForReporter(
 	setup *PrometheusAPISetup,
 ) (v1.API, error) {
-	if setup.PromService == nil {
-		return nil, errors.New("prom service is not provided")
-	}
-	if setup.PromPort == nil {
-		return nil, errors.New("prom port is not provided")
-	}
 
 	if setup.RunLocal {
 		client, err := api.NewClient(api.Config{
@@ -143,6 +137,13 @@ func providePrometheusAPIForReporter(
 
 		localClient := v1.NewAPI(client)
 		return localClient, nil
+	} else {
+		if setup.PromService == nil {
+			return nil, errors.New("prom service is not provided")
+		}
+		if setup.PromPort == nil {
+			return nil, errors.New("prom port is not provided")
+		}
 	}
 
 	name := setup.PromService.Name

--- a/v2/pkg/prometheus/prometheus_client.go
+++ b/v2/pkg/prometheus/prometheus_client.go
@@ -125,7 +125,6 @@ func providePrometheusAPI(
 func providePrometheusAPIForReporter(
 	setup *PrometheusAPISetup,
 ) (v1.API, error) {
-
 	if setup.RunLocal {
 		client, err := api.NewClient(api.Config{
 			Address: "http://127.0.0.1:9090",
@@ -144,6 +143,13 @@ func providePrometheusAPIForReporter(
 		if setup.PromPort == nil {
 			return nil, errors.New("prom port is not provided")
 		}
+	}
+
+	if setup.PromService == nil {
+		return nil, errors.New("prom service is not provided")
+	}
+	if setup.PromPort == nil {
+		return nil, errors.New("prom port is not provided")
 	}
 
 	name := setup.PromService.Name

--- a/v2/tools/connect/pkg/client.go
+++ b/v2/tools/connect/pkg/client.go
@@ -172,8 +172,6 @@ func (c *connectClient) GetTag(opsid, digest string) (*pcTag, error) {
 	q.Add("digests", digest)
 	req.URL.RawQuery = q.Encode()
 
-	fmt.Println(req.URL.String())
-
 	resp, err := c.Do(req)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Local execution had a lot of issues with variables being used when not necessary. While running a report now this tool will work if using local values:
```
go run cmd/reporter/main.go report --name meter-report-2021-12-13 --namespace openshift-redhat-marketplace --local --uploadTargets=local-path --localFilePath=`pwd`
```

will now work as expected.

Note: you have to port-forward 9090 from the prometheus you're querying