### PR TITLE
requeue if olm.operatorNamespace isn't set yet

### DIFF
--- a/v2/controllers/marketplace/clusterserviceversion_controller.go
+++ b/v2/controllers/marketplace/clusterserviceversion_controller.go
@@ -314,8 +314,9 @@ func (r *ClusterServiceVersionReconciler) reconcileMeterDefAnnotation(CSV *olmv1
 
 	if !ok {
 		reqLogger.Info("olm.operatorNamespace is not set yet, requeuing")
-		return reconcile.Result{RequeueAfter: time.Second * 5}, true, err
+		return reconcile.Result{RequeueAfter: time.Second * 5}, true, nil
 	}
+
 	// builds a meterdefinition from our string (from the annotation)
 	reqLogger.Info("retrieval successful", "str", meterDefinitionString)
 

--- a/v2/controllers/marketplace/clusterserviceversion_jsonannotation_test.go
+++ b/v2/controllers/marketplace/clusterserviceversion_jsonannotation_test.go
@@ -61,6 +61,9 @@ var _ = Describe("JsonMeterDefValidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "n",
 				Namespace: "ns",
+				Annotations: map[string]string{
+					olmNamespace: "test-namespace",
+				},
 			},
 		}
 	})
@@ -96,7 +99,7 @@ var _ = Describe("JsonMeterDefValidation", func() {
 			  }
 			}
 		  }`
-			annBad       = map[string]string{utils.CSV_METERDEFINITION_ANNOTATION: meterDefJsonBad}
+			annBad       = map[string]string{utils.CSV_METERDEFINITION_ANNOTATION: meterDefJsonBad, olmNamespace: "test-namespace"}
 			meterDefJson = `{
         "apiVersion": "marketplace.redhat.com/v1alpha1",
         "kind": "MeterDefinition",
@@ -131,7 +134,6 @@ var _ = Describe("JsonMeterDefValidation", func() {
 
 		BeforeEach(func() {
 			meterDefinition = &marketplacev1alpha1.MeterDefinition{}
-
 			//meterDefinitionNew = nil
 			gvk = &schema.GroupVersionKind{}
 			gvk.Kind = "ClusterServiceVersion"


### PR DESCRIPTION
For: https://github.ibm.com/symposium/track-and-plan/issues/22915

Our predicates were looking for the csv namespace to match the namespace set by olm on `olm.operatorNamespace` upon creation of the csv
```

func csvFilter(metaNew metav1.Object) int {
	ann := metaNew.GetAnnotations()

	//annotation values
	ignoreVal, hasIgnoreTag := ann[ignoreTag]
	_, hasCopiedFrom := ann[olmCopiedFromTag]
	_, hasMeterDefinition := ann[utils.CSV_METERDEFINITION_ANNOTATION]

	sameNamespace := ann[olmNamespace] == metaNew.GetNamespace()

	switch {
	// has meterdef && is not an all namespace install
	case hasMeterDefinition && !hasCopiedFrom && sameNamespace:
		return 1
	// does not have a meterdef and
	case !hasMeterDefinition && (!hasIgnoreTag || ignoreVal != ignoreTagValue):
		return 2
	default:
	}

	return 0
}
```
The problem is, OLM is sometimes slow to set `olm.operatorNamespace` meaning our create predicate returns false when the csv first gets created and `olm.operatorNamespace` isn't set. 

Also, our update predicate only passes when there is an update to the csv AND an update to the meterdefinition housed in `marketplace.redhat.com/meterDefinition`. So if a csv is missing `olm.operatorNamespace` when our create predicate picks it up, it won't pass the create or update predicate and never get reconciled, unless you update the meterdef on the csv annotations

...this is why restarting the operator pod would pass the create predicate and the csv would get reconciled - when you restart the pod `olm.operatorNamespace` has had a few seconds to get set and is present on the csv annotations when the the `ClusterServiceVersionReconciler` runs.