### PR TITLE
fix: v4.9-v4.10 rhm-prometheus service

### DIFF
--- a/v2/assets/prometheus/service.yaml
+++ b/v2/assets/prometheus/service.yaml
@@ -15,7 +15,6 @@ spec:
     port: 9092
     targetPort: rbac
   selector:
-    app: prometheus
     prometheus: meterbase
   sessionAffinity: ClientIP
   type: ClusterIP

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -148,6 +148,14 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+    - security.openshift.io
+    resourceNames:
+    - nonroot
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
 ---
 # Source: redhat-marketplace-operator-template-chart/templates/role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -93,6 +93,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get
@@ -442,6 +448,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -275,9 +275,14 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=prometheuses;servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="operators.coreos.com",namespace=system,resources=subscriptions,verbs=get;list;watch;create
+
+// RHM Prometheus
+// +kubebuilder:rbac:groups="",resources=nodes/metrics,verbs=get
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 // +kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create
+// included-above groups="",resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=nonroot,resources=securitycontextconstraints,verbs=use
 
 // Reconcile reads that state of the cluster for a MeterBase object and makes changes based on the state read
 // and what is in the MeterBase.Spec


### PR DESCRIPTION
ose-prometheus:v4.10 used for rhm-prometheus no longer adds the label `app: prometheus` to prometheus pods
this was causing calls to the prometheus service endpoint to fail
do not use it as a service label selector
v4.6-v4.10 retains use of the `prometheus: ` label, continue to use that as the selector

---

add required rbac for rhm-prometheus kubelet servicemonitor 