### PR TITLE
added cpu and memory limits on data-service

### DIFF
--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -64,9 +64,12 @@ spec:
             - containerPort: 9001
               name: db
           resources:
-            requests:
+            limits:
               cpu: 100m
-              memory: 25Mi
+              memory: 250Mi
+            requests:
+              cpu: 25m
+              memory: 50Mi
           volumeMounts:
             - name: rhm-data-service
               mountPath: /data


### PR DESCRIPTION
For: https://github.ibm.com/symposium/track-and-plan/issues/24058

- Adds resource limit to `assets/dataservice/statefulset.yaml`
