### PR TITLE
fix unregister reponse handling

### DIFF
--- a/v2/pkg/marketplace/marketplace_client.go
+++ b/v2/pkg/marketplace/marketplace_client.go
@@ -404,7 +404,6 @@ func (m *MarketplaceClient) getClusterObjID(account *MarketplaceClientAccount) (
 		return "", err
 	}
 
-	utils.PrettyPrint(string(clusterDef))
 	registrations, err := getRegistrations(string(clusterDef))
 
 	var objId string
@@ -457,35 +456,16 @@ func (m *MarketplaceClient) UnRegister(account *MarketplaceClientAccount) (Regis
 			Err:                err,
 			StatusCode:         http.StatusInternalServerError,
 		}, err
-	}
-	if resp.StatusCode != 200 {
+	} else if resp.StatusCode == 200 {
+		return RegistrationStatusOutput{
+			StatusCode:         resp.StatusCode,
+			RegistrationStatus: "UNREGISTERED",
+		}, nil
+	} else {
 		return RegistrationStatusOutput{
 			RegistrationStatus: "HttpError",
 			Err:                err,
 			StatusCode:         resp.StatusCode,
 		}, err
 	}
-
-	logger.Info("Un-register call status code", "httpstatus", resp.StatusCode)
-	clusterDef, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
-
-	if err != nil {
-		return RegistrationStatusOutput{Err: err}, err
-	}
-
-	registrations, err := getRegistrations(string(clusterDef))
-	if err != nil {
-		return RegistrationStatusOutput{Err: err}, err
-	}
-
-	var unregistered RegistrationStatusOutput
-	if len(registrations) == 0 {
-		unregistered = RegistrationStatusOutput{
-			StatusCode:         resp.StatusCode,
-			RegistrationStatus: "UNREGISTERED",
-		}
-	}
-
-	return unregistered, nil
 }


### PR DESCRIPTION
The response body of a PATCH call to RegistrationEndpoint is empty
- Do not try to parse the response body as json via getRegistrations, it just throws an error
- A 200 OK indicates we are successful
- Just return an UNREGISTERED for RegistrationStatusOutput if we got a 200 OK
- get rid of a debug print

---

Could be extra diligent, but this does hold up our finalizer

- Check RegistrationEndpoint registrationStatus for TO_BE_UNREGISTERED status after the RegistrationEndpoint PATCH call
- retryablehttp a few times if we failed