### PR TITLE
fix: csv filter

### DIFF
--- a/v2/controllers/marketplace/clusterserviceversion_controller.go
+++ b/v2/controllers/marketplace/clusterserviceversion_controller.go
@@ -431,9 +431,15 @@ func csvFilter(metaNew metav1.Object) int {
 	return 0
 }
 
+func checkForUpdateToMdef(evt event.UpdateEvent) bool {
+	oldMeterDefVal, oldOk := evt.ObjectOld.GetAnnotations()[utils.CSV_METERDEFINITION_ANNOTATION]
+	newMeterDefVal, newOk := evt.ObjectNew.GetAnnotations()[utils.CSV_METERDEFINITION_ANNOTATION]
+	return oldOk && newOk && oldMeterDefVal != newMeterDefVal
+}
+
 var clusterServiceVersionPredictates predicate.Funcs = predicate.Funcs{
 	UpdateFunc: func(evt event.UpdateEvent) bool {
-		return csvFilter(evt.ObjectNew) > 0
+		return csvFilter(evt.ObjectNew) > 0 && checkForUpdateToMdef(evt)
 	},
 	DeleteFunc: func(evt event.DeleteEvent) bool {
 		return false

--- a/v2/controllers/marketplace/clusterserviceversion_controller.go
+++ b/v2/controllers/marketplace/clusterserviceversion_controller.go
@@ -103,17 +103,6 @@ func (r *ClusterServiceVersionReconciler) Reconcile(ctx context.Context, request
 		annotations = make(map[string]string)
 	}
 
-	// check if CSV is being deleted
-	// if yes -> finalizer logic
-	// if no -> do nothing
-	if !CSV.ObjectMeta.DeletionTimestamp.IsZero() {
-		//Run finalization logic for the CSV.
-		result, isReconcile, err := r.finalizeCSV(CSV)
-		if isReconcile {
-			return result, err
-		}
-	}
-
 	result, isRequeue, err := r.reconcileMeterDefAnnotation(CSV, annotations)
 
 	// check if err is instance of json.parsing error
@@ -225,67 +214,6 @@ func (r *ClusterServiceVersionReconciler) Reconcile(ctx context.Context, request
 
 	reqLogger.Info("reconciliation complete")
 	return reconcile.Result{RequeueAfter: time.Minute * 1}, nil
-}
-
-func (r *ClusterServiceVersionReconciler) finalizeCSV(CSV *olmv1alpha1.ClusterServiceVersion) (reconcile.Result, bool, error) {
-	reqLogger := r.Log.WithValues("Request.Name", CSV.GetName(), "Request.Namespace", CSV.GetNamespace())
-
-	reqLogger.Info("deleting csv")
-	if err := r.deleteExternalResources(CSV); err != nil {
-		reqLogger.Error(err, "unable to delete csv")
-		return reconcile.Result{}, false, err
-	}
-
-	// Stop reconciliation as the item is being deleted
-	return reconcile.Result{}, true, nil
-}
-
-// deleteExternalResources searches for the MeterDefinition created by the CSV, if it's found delete it
-func (r *ClusterServiceVersionReconciler) deleteExternalResources(CSV *olmv1alpha1.ClusterServiceVersion) error {
-	reqLogger := r.Log.WithValues("Request.Name", CSV.GetName(), "Request.Namespace", CSV.GetNamespace())
-	reqLogger.Info("deleting csv")
-
-	annotations := CSV.GetAnnotations()
-	if annotations == nil {
-		reqLogger.Info("No annotations for this CSV")
-		return nil
-	}
-
-	meterDefinitionString, ok := annotations[utils.CSV_METERDEFINITION_ANNOTATION]
-	if !ok {
-		reqLogger.Info("No value for ", "key: ", utils.CSV_METERDEFINITION_ANNOTATION)
-		return nil
-	}
-
-	var errAlpha, errBeta error
-	meterDefinitionBeta := &marketplacev1beta1.MeterDefinition{}
-	meterDefinitionAlpha := &marketplacev1alpha1.MeterDefinition{}
-
-	errBeta = meterDefinitionBeta.BuildMeterDefinitionFromString(meterDefinitionString, CSV.GetName(), CSV.GetNamespace(), utils.CSV_ANNOTATION_NAME, utils.CSV_ANNOTATION_NAMESPACE)
-
-	if errBeta != nil {
-		errAlpha = meterDefinitionAlpha.BuildMeterDefinitionFromString(meterDefinitionString, CSV.GetName(), CSV.GetNamespace(), utils.CSV_ANNOTATION_NAME, utils.CSV_ANNOTATION_NAMESPACE)
-	}
-
-	switch {
-	case errBeta == nil:
-		err := r.Client.Delete(context.TODO(), meterDefinitionBeta, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		if err != nil && errors.IsNotFound(err) {
-			return err
-		}
-	case errAlpha == nil:
-		err := r.Client.Delete(context.TODO(), meterDefinitionAlpha, client.PropagationPolicy(metav1.DeletePropagationForeground))
-		if err != nil && errors.IsNotFound(err) {
-			return err
-		}
-	default:
-		err := emperrors.Combine(errBeta, errAlpha)
-		reqLogger.Error(err, "Could not build a local copy of the MeterDefinition")
-		return err
-	}
-
-	reqLogger.Info("found and deleted MeterDefinition")
-	return nil
 }
 
 // reconcileMeterDefAnnotation checks the Annotations for the rhm CSV
@@ -485,10 +413,11 @@ func (r *ClusterServiceVersionReconciler) reconcileMeterDefAnnotation(CSV *olmv1
 
 func csvFilter(metaNew metav1.Object) int {
 	ann := metaNew.GetAnnotations()
+	labels := metaNew.GetLabels()
 
 	//annotation values
 	ignoreVal, hasIgnoreTag := ann[ignoreTag]
-	_, hasCopiedFrom := ann[olmCopiedFromTag]
+	_, hasCopiedFrom := labels[olmCopiedFromTag]
 	_, hasMeterDefinition := ann[utils.CSV_METERDEFINITION_ANNOTATION]
 
 	switch {
@@ -502,18 +431,12 @@ func csvFilter(metaNew metav1.Object) int {
 	return 0
 }
 
-func checkForUpdateToMdef(evt event.UpdateEvent) bool {
-	oldMeterDefVal, oldOk := evt.ObjectOld.GetAnnotations()[utils.CSV_METERDEFINITION_ANNOTATION]
-	newMeterDefVal, newOk := evt.ObjectNew.GetAnnotations()[utils.CSV_METERDEFINITION_ANNOTATION]
-	return oldOk && newOk && oldMeterDefVal != newMeterDefVal
-}
-
 var clusterServiceVersionPredictates predicate.Funcs = predicate.Funcs{
 	UpdateFunc: func(evt event.UpdateEvent) bool {
-		return csvFilter(evt.ObjectNew) > 0 && checkForUpdateToMdef(evt)
+		return csvFilter(evt.ObjectNew) > 0
 	},
 	DeleteFunc: func(evt event.DeleteEvent) bool {
-		return true
+		return false
 	},
 	CreateFunc: func(evt event.CreateEvent) bool {
 		return csvFilter(evt.Object) > 0

--- a/v2/controllers/marketplace/clusterserviceversion_controller_test.go
+++ b/v2/controllers/marketplace/clusterserviceversion_controller_test.go
@@ -52,18 +52,19 @@ var _ = Describe("ClusterServiceVersion controller", func() {
 			ignoreTag: ignoreTagValue,
 		}, empty, 0),
 		Entry("deny mdef with copied from", map[string]string{
-			olmCopiedFromTag:                     "foo",
 			utils.CSV_METERDEFINITION_ANNOTATION: "some meterdef",
-		}, empty, 0),
+		}, map[string]string{
+			olmCopiedFromTag: "foo",
+		}, 0),
 		Entry("accept mdef without copied from", map[string]string{
 			utils.CSV_METERDEFINITION_ANNOTATION: "some meterdef",
 		}, empty, 1),
 	)
 
 	Context("predicates", func() {
-		It("should allow delete events", func() {
+		It("should deny delete events", func() {
 			evt := event.DeleteEvent{}
-			Expect(clusterServiceVersionPredictates.Delete(evt)).To(BeTrue())
+			Expect(clusterServiceVersionPredictates.Delete(evt)).To(BeFalse())
 		})
 		It("should deny generic events", func() {
 			evt := event.GenericEvent{}


### PR DESCRIPTION
This is for 24809 opened against RC 2.7.1

- Do not reconcile CSV deletes
  - We do not set finalizers on CSVs
  - Remove MeterDefinition delete logic, they are removed via OwnerRef
- Fix the csvFilter predicate
  - olmCopiedFromTag  / olm.copiedFrom is a Label not an Annotation, so the predicate was not filtering as intended
  - We were still reconciling for CSV copies, though reconcileMeterDefAnnotation() would catch these as copies and return anyways
 
 
There may still be an `Error Not Found` due to timing, as OLM fires a Status update against the primary CSV as an operator is being deleted. We can't ignore Status update events, as we consume Status in our reconcile.