### PR TITLE
bugfix: fix nil pointer

### DIFF
--- a/authchecker/v2/pkg/authchecker/authchecker_test.go
+++ b/authchecker/v2/pkg/authchecker/authchecker_test.go
@@ -62,6 +62,24 @@ var _ = Describe("authchecker", func() {
 		mock.AssertExpectationsForObjects(GinkgoT(), mockClient)
 	})
 
+	It("should init tokenReview field if it's nil", func() {
+		sut.tokenReview = nil
+
+		mockClient.On("Create", ctx, mock.Anything, mock.Anything).Times(1).Return(&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]interface{}{
+					"authenticated": true,
+				},
+			},
+		}, nil)
+
+		err := sut.CheckToken(ctx)
+		Expect(err).To(Succeed())
+		Expect(sut.Check(nil)).To(Succeed())
+
+		mock.AssertExpectationsForObjects(GinkgoT(), mockClient)
+	})
+
 	It("should error if token is invalid", func() {
 		mockClient.On("Create", ctx, mock.Anything, mock.Anything).Times(1).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{


### PR DESCRIPTION
Fix for bug [24892](https://github.ibm.com/symposium/track-and-plan/issues/24892)

Sigfaults:
```
2022-05-16T22:39:31.659Z  INFO   controller-runtime.healthz  healthz check failed  {"statuses": [{}]}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x98b5f9]

goroutine 7 [running]:
github.com/redhat-marketplace/redhat-marketplace-operator/authchecker/v2/pkg/authchecker.(*AuthChecker).CheckToken(0xc0002d8100, {0xc22858, 0xc000290700})
  /src/authchecker/v2/pkg/authchecker/authchecker.go:98 +0x59
github.com/redhat-marketplace/redhat-marketplace-operator/authchecker/v2/pkg/authchecker.(*AuthChecker).Start.func1()
  /src/authchecker/v2/pkg/authchecker/authchecker.go:80 +0xd9
created by github.com/redhat-marketplace/redhat-marketplace-operator/authchecker/v2/pkg/authchecker.(*AuthChecker).Start
  /src/authchecker/v2/pkg/authchecker/authchecker.go:74 +0xd3

      Exit Code:    2
      Started:      Fri, 13 May 2022 02:26:47 -0700
      Finished:     Mon, 16 May 2022 15:39:50 -0700
    Ready:          True
    Restart Count:  1
```
