### PR TITLE
bugfix: no data due to permissions

### DIFF
--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -38,6 +38,10 @@ rules:
   verbs:
   - get
 - nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+- nonResourceURLs:
   - /system-meterdef-index/*
   verbs:
   - get
@@ -129,6 +133,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - marketplace.redhat.com
+  resources:
+  - meterdefinitions/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -317,7 +330,6 @@ rules:
   resources:
   - secrets
   verbs:
-  - delete
   - patch
   - update
 - apiGroups:

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -273,6 +273,7 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=update;patch;delete,resourceNames=rhm-meter-report-upload
+// +kubebuilder:rbac:urls=/metrics,verbs=get
 
 // Reconcile reads that state of the cluster for a MeterBase object and makes changes based on the state read
 // and what is in the MeterBase.Spec


### PR DESCRIPTION
Fix for [24843](https://github.ibm.com/symposium/track-and-plan/issues/24843).

Adding nonResourceURLS /metrics for the rhm-metric-state service monitor token to work.
