### PR TITLE
Fix finalizers & ownerRefs

### DIFF
--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -288,14 +288,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secret
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -320,33 +312,22 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - rhm-data-service-mtls
-  resources:
-  - secrets
-  verbs:
-  - delete
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - secrets/finalizers
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resourceNames:
   - ibm-entitlement-key
   - redhat-marketplace-pull-secret
   - rhm-operator-secret
   resources:
   - secrets
-  - secrets/finalizers
   verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resourceNames:
+  - rhm-data-service-mtls
+  resources:
+  - secrets
+  verbs:
+  - delete
   - patch
   - update
 - apiGroups:

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -130,6 +130,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - marketplace.redhat.com
+  resources:
+  - meterdefinitions/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - operators.coreos.com
   resources:
   - catalogsources
@@ -311,9 +320,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - ibm-entitlement-key
-  - redhat-marketplace-pull-secret
-  - rhm-operator-secret
+  - rhm-data-service-mtls
   resources:
   - secrets
   verbs:
@@ -322,12 +329,24 @@ rules:
   - update
 - apiGroups:
   - ""
-  resourceNames:
-  - rhm-data-service-mtls
   resources:
   - secrets
+  - secrets/finalizers
   verbs:
-  - delete
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - ibm-entitlement-key
+  - redhat-marketplace-pull-secret
+  - rhm-operator-secret
+  resources:
+  - secrets
+  - secrets/finalizers
+  verbs:
   - patch
   - update
 - apiGroups:
@@ -427,15 +446,38 @@ rules:
   - update
 - apiGroups:
   - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
   resourceNames:
   - rhm-remoteresources3-controller
   - rhm-watch-keeper
   resources:
   - deployments
+  - deployments/finalizers
   verbs:
   - delete
   - patch
   - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - redhat-marketplace-controller-manager
+  resources:
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -558,6 +600,7 @@ rules:
   - marketplaceconfigs/finalizers
   - marketplaceconfigs/status
   verbs:
+  - delete
   - get
   - list
   - patch

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -567,20 +567,10 @@ rules:
   - marketplace.redhat.com
   resources:
   - marketplaceconfigs
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - marketplace.redhat.com
-  resources:
-  - marketplaceconfigs
   - marketplaceconfigs/finalizers
   - marketplaceconfigs/status
   verbs:
+  - create
   - delete
   - get
   - list

--- a/v2/controllers/marketplace/clusterregistration_controller.go
+++ b/v2/controllers/marketplace/clusterregistration_controller.go
@@ -67,8 +67,8 @@ type SecretInfo struct {
 	MissingMsg string
 }
 
-// +kubebuilder:rbac:groups="",namespace=system,resources=secrets;secrets/finalizers,verbs=get;list;watch;create
-// +kubebuilder:rbac:groups="",namespace=system,resources=secrets;secrets/finalizers,resourceNames=redhat-marketplace-pull-secret;ibm-entitlement-key;rhm-operator-secret,verbs=update;patch
+// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,resourceNames=redhat-marketplace-pull-secret;ibm-entitlement-key;rhm-operator-secret,verbs=update;patch
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=get;list;watch
 
@@ -120,18 +120,6 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 	}
 
 	reqLogger.Info("Marketplace Token Claims set")
-
-	// set secret owner as controller deployment and set finalizer
-	// marketplaceconfig & secret are needed to complete unregistration on uninstall, as part of the marketplaceconfig finalizer process
-	/*
-			if !controllerutil.ContainsFinalizer(si.Secret, utils.CONTROLLER_FINALIZER) {
-				controllerutil.AddFinalizer(si.Secret, utils.CONTROLLER_FINALIZER)
-			}
-
-		if err := r.setControllerReference(si.Secret); err != nil {
-			return reconcile.Result{}, err
-		}
-	*/
 
 	err = r.Client.Update(context.TODO(), si.Secret)
 	if err != nil {

--- a/v2/controllers/marketplace/clusterregistration_controller.go
+++ b/v2/controllers/marketplace/clusterregistration_controller.go
@@ -124,13 +124,14 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 	// set secret owner as controller deployment and set finalizer
 	// marketplaceconfig & secret are needed to complete unregistration on uninstall, as part of the marketplaceconfig finalizer process
 	/*
-		if !controllerutil.ContainsFinalizer(si.Secret, utils.CONTROLLER_FINALIZER) {
-			controllerutil.AddFinalizer(si.Secret, utils.CONTROLLER_FINALIZER)
+			if !controllerutil.ContainsFinalizer(si.Secret, utils.CONTROLLER_FINALIZER) {
+				controllerutil.AddFinalizer(si.Secret, utils.CONTROLLER_FINALIZER)
+			}
+
+		if err := r.setControllerReference(si.Secret); err != nil {
+			return reconcile.Result{}, err
 		}
 	*/
-	if err := r.setControllerReference(si.Secret); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	err = r.Client.Update(context.TODO(), si.Secret)
 	if err != nil {
@@ -314,7 +315,7 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 				newMarketplaceConfig.Spec.RhmAccountID = tokenClaims.AccountID
 			}
 
-			if err = controllerutil.SetControllerReference(si.Secret, newMarketplaceConfig, r.Scheme); err != nil {
+			if err := r.setControllerReference(newMarketplaceConfig); err != nil {
 				return reconcile.Result{}, err
 			}
 
@@ -334,7 +335,8 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 	}
 
 	owners := newMarketplaceConfig.GetOwnerReferences()
-	if err = controllerutil.SetControllerReference(si.Secret, newMarketplaceConfig, r.Scheme); err != nil {
+
+	if err := r.setControllerReference(newMarketplaceConfig); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/v2/controllers/marketplace/clusterregistration_controller.go
+++ b/v2/controllers/marketplace/clusterregistration_controller.go
@@ -69,8 +69,10 @@ type SecretInfo struct {
 
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,resourceNames=redhat-marketplace-pull-secret;ibm-entitlement-key;rhm-operator-secret,verbs=update;patch
-// +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs;marketplaceconfigs/finalizers;marketplaceconfigs/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments;deployments/finalizers,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments/finalizers,verbs=get;list;watch;update;patch,resourceNames=redhat-marketplace-controller-manager
 
 // Reconcile reads that state of the cluster for a ClusterRegistration object and makes changes based on the state read
 // and what is in the ClusterRegistration.Spec
@@ -120,12 +122,6 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 	}
 
 	reqLogger.Info("Marketplace Token Claims set")
-
-	err = r.Client.Update(context.TODO(), si.Secret)
-	if err != nil {
-		reqLogger.Error(err, "Failed to update Secret")
-		return reconcile.Result{}, err
-	}
 
 	newMarketplaceConfig := &marketplacev1alpha1.MarketplaceConfig{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -77,8 +77,10 @@ type MarketplaceConfigReconciler struct {
 
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",namespace=system,resources=namespaces,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="",namespace=system,resources=secret,verbs=get;list;watch
-// +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs;marketplaceconfigs/finalizers;marketplaceconfigs/status,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments;deployments/finalizers,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments/finalizers,verbs=get;list;watch;update;patch,resourceNames=redhat-marketplace-controller-manager
+// +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs;marketplaceconfigs/finalizers;marketplaceconfigs/status,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=razeedeployments,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=razeedeployments,verbs=update;patch;delete,resourceNames=rhm-marketplaceconfig-razeedeployment
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=meterbases,verbs=get;list;watch;create

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -78,8 +78,6 @@ type MarketplaceConfigReconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",namespace=system,resources=namespaces,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments;deployments/finalizers,verbs=get;list;watch
-// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments/finalizers,verbs=get;list;watch;update;patch,resourceNames=redhat-marketplace-controller-manager
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=marketplaceconfigs;marketplaceconfigs/finalizers;marketplaceconfigs/status,verbs=get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=razeedeployments,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=razeedeployments,verbs=update;patch;delete,resourceNames=rhm-marketplaceconfig-razeedeployment

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -307,32 +307,6 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 		return result.Return()
 	}
 
-	// Execute the finalizer, will only run if we are in delete state
-	/*
-		if result, _ = cc.Do(
-			context.TODO(),
-			Call(SetFinalizer(instance, utils.CONTROLLER_FINALIZER)),
-			Call(
-				RunFinalizer(instance, utils.CONTROLLER_FINALIZER,
-					Do(r.uninstallPrometheusOperator(instance)...),
-					Do(r.uninstallPrometheus(instance)...),
-					Do(r.uninstallMetricState(instance)...),
-					Do(r.uninstallPrometheusServingCertsCABundle()...),
-					Do(r.uninstallUserWorkloadMonitoring()...),
-				)),
-		); !result.Is(Continue) {
-			if result.Is(Error) {
-				reqLogger.Error(result.GetError(), "Failed to get MeterBase.")
-			}
-
-			if result.Is(Return) {
-				reqLogger.Info("Delete is complete.")
-			}
-
-			return result.Return()
-		}
-	*/
-
 	// if instance.Enabled == false
 	// return do nothing
 	if !instance.Spec.Enabled {

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -308,28 +308,30 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	// Execute the finalizer, will only run if we are in delete state
-	if result, _ = cc.Do(
-		context.TODO(),
-		Call(SetFinalizer(instance, utils.CONTROLLER_FINALIZER)),
-		Call(
-			RunFinalizer(instance, utils.CONTROLLER_FINALIZER,
-				Do(r.uninstallPrometheusOperator(instance)...),
-				Do(r.uninstallPrometheus(instance)...),
-				Do(r.uninstallMetricState(instance)...),
-				Do(r.uninstallPrometheusServingCertsCABundle()...),
-				Do(r.uninstallUserWorkloadMonitoring()...),
-			)),
-	); !result.Is(Continue) {
-		if result.Is(Error) {
-			reqLogger.Error(result.GetError(), "Failed to get MeterBase.")
-		}
+	/*
+		if result, _ = cc.Do(
+			context.TODO(),
+			Call(SetFinalizer(instance, utils.CONTROLLER_FINALIZER)),
+			Call(
+				RunFinalizer(instance, utils.CONTROLLER_FINALIZER,
+					Do(r.uninstallPrometheusOperator(instance)...),
+					Do(r.uninstallPrometheus(instance)...),
+					Do(r.uninstallMetricState(instance)...),
+					Do(r.uninstallPrometheusServingCertsCABundle()...),
+					Do(r.uninstallUserWorkloadMonitoring()...),
+				)),
+		); !result.Is(Continue) {
+			if result.Is(Error) {
+				reqLogger.Error(result.GetError(), "Failed to get MeterBase.")
+			}
 
-		if result.Is(Return) {
-			reqLogger.Info("Delete is complete.")
-		}
+			if result.Is(Return) {
+				reqLogger.Info("Delete is complete.")
+			}
 
-		return result.Return()
-	}
+			return result.Return()
+		}
+	*/
 
 	// if instance.Enabled == false
 	// return do nothing
@@ -691,7 +693,11 @@ func (r *MeterBaseReconciler) reconcilePrometheusOperator(
 		manifests.CreateOrUpdateFactoryItemAction(
 			service,
 			func() (client.Object, error) {
-				return r.factory.NewPrometheusOperatorService()
+				obj, err := r.factory.NewPrometheusOperatorService()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
@@ -704,7 +710,11 @@ func (r *MeterBaseReconciler) reconcilePrometheusOperator(
 				}
 				sort.Strings(nsValues)
 				reqLogger.Info("found namespaces", "ns", nsValues)
-				return r.factory.NewPrometheusOperatorDeployment(nsValues)
+				obj, err := r.factory.NewPrometheusOperatorDeployment(nsValues)
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
@@ -848,42 +858,66 @@ func (r *MeterBaseReconciler) installMetricStateDeployment(
 		manifests.CreateOrUpdateFactoryItemAction(
 			metricStateDeployment,
 			func() (client.Object, error) {
-				return r.factory.MetricStateDeployment()
+				obj, err := r.factory.MetricStateDeployment()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			metricStateService,
 			func() (client.Object, error) {
-				return r.factory.MetricStateService()
+				obj, err := r.factory.MetricStateService()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			metricStateServiceMonitor,
 			func() (client.Object, error) {
-				return r.factory.MetricStateServiceMonitor(&secret.Name)
+				obj, err := r.factory.MetricStateServiceMonitor(&secret.Name)
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			metricStateMeterDefinition,
 			func() (client.Object, error) {
-				return r.factory.MetricStateMeterDefinition()
+				obj, err := r.factory.MetricStateMeterDefinition()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			kubeStateMetricsService,
 			func() (client.Object, error) {
-				return r.factory.KubeStateMetricsService()
+				obj, err := r.factory.KubeStateMetricsService()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			reporterMeterDefinition,
 			func() (client.Object, error) {
-				return r.factory.ReporterMeterDefinition()
+				obj, err := r.factory.ReporterMeterDefinition()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
@@ -898,14 +932,22 @@ func (r *MeterBaseReconciler) installMetricStateDeployment(
 			manifests.CreateOrUpdateFactoryItemAction(
 				kubeStateMetricsServiceMonitor,
 				func() (client.Object, error) {
-					return r.factory.KubeStateMetricsServiceMonitor(&secret.Name)
+					obj, err := r.factory.KubeStateMetricsServiceMonitor(&secret.Name)
+					if err == nil {
+						r.factory.SetControllerReference(instance, obj)
+					}
+					return obj, err
 				},
 				args,
 			),
 			manifests.CreateOrUpdateFactoryItemAction(
 				kubeletServiceMonitor,
 				func() (client.Object, error) {
-					return r.factory.KubeletServiceMonitor(&secret.Name)
+					obj, err := r.factory.KubeletServiceMonitor(&secret.Name)
+					if err == nil {
+						r.factory.SetControllerReference(instance, obj)
+					}
+					return obj, err
 				},
 				args,
 			),
@@ -1128,36 +1170,60 @@ func (r *MeterBaseReconciler) reconcilePrometheus(
 		manifests.CreateIfNotExistsFactoryItem(
 			&corev1.ConfigMap{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusServingCertsCABundle()
+				obj, err := r.factory.PrometheusServingCertsCABundle()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 		),
 		manifests.CreateIfNotExistsFactoryItem(
 			dataSecret,
 			func() (client.Object, error) {
-				return r.factory.PrometheusDatasources()
+				obj, err := r.factory.PrometheusDatasources()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			}),
 		manifests.CreateIfNotExistsFactoryItem(
 			&corev1.Secret{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusProxySecret()
+				obj, err := r.factory.PrometheusProxySecret()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			}),
 		manifests.CreateIfNotExistsFactoryItem(
 			&corev1.Secret{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusRBACProxySecret()
+				obj, err := r.factory.PrometheusRBACProxySecret()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			&monitoringv1.ServiceMonitor{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusServiceMonitor()
+				obj, err := r.factory.PrometheusServiceMonitor()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
 		manifests.CreateOrUpdateFactoryItemAction(
 			&marketplacev1beta1.MeterDefinition{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusMeterDefinition()
+				obj, err := r.factory.PrometheusMeterDefinition()
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args,
 		),
@@ -1170,7 +1236,11 @@ func (r *MeterBaseReconciler) reconcilePrometheus(
 					return nil, errors.New("basicAuthSecret not on data")
 				}
 
-				return r.factory.PrometheusHtpasswdSecret(string(data))
+				obj, err := r.factory.PrometheusHtpasswdSecret(string(data))
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			}),
 			OnError(RequeueResponse()),
 		),
@@ -1193,7 +1263,11 @@ func (r *MeterBaseReconciler) reconcilePrometheus(
 		manifests.CreateOrUpdateFactoryItemAction(
 			&corev1.Service{},
 			func() (client.Object, error) {
-				return r.factory.PrometheusService(instance.Name)
+				obj, err := r.factory.PrometheusService(instance.Name)
+				if err == nil {
+					r.factory.SetControllerReference(instance, obj)
+				}
+				return obj, err
 			},
 			args),
 		HandleResult(

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -334,30 +334,6 @@ func (r *RazeeDeploymentReconciler) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	/*
-		// Adding a finalizer to this CR
-		if !utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
-			if err := r.addFinalizer(instance, request.Namespace); err != nil {
-				return reconcile.Result{}, err
-			}
-
-			return reconcile.Result{Requeue: true}, nil
-		}
-	*/
-
-	// Check if the RazeeDeployment instance is being marked for deletion
-	/*
-		isMarkedForDeletion := instance.GetDeletionTimestamp() != nil
-		if isMarkedForDeletion {
-			if utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
-				//Run finalization logic for the RAZEE_DEPLOYMENT_FINALIZER.
-				//If it fails, don't remove the finalizer so we can retry during the next reconcile
-				return r.fullUninstall(instance)
-			}
-			return reconcile.Result{}, nil
-		}
-	*/
-
 	isMarkedForDeletion := instance.GetDeletionTimestamp() != nil
 	if isMarkedForDeletion {
 		return reconcile.Result{}, nil

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -241,8 +241,8 @@ func (r *RazeeDeploymentReconciler) SetupWithManager(mgr manager.Manager) error 
 // +kubebuilder:rbac:groups="",namespace=system,resources=configmaps,verbs=update;patch;delete,resourceNames=watch-keeper-non-namespaced;watch-keeper-limit-poll;razee-cluster-metadata;watch-keeper-config
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=update;patch;delete,resourceNames=rhm-operator-secret;watch-keeper-secret;clustersubscription
-// +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=get;list;watch;create
-// +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments,verbs=update;patch;delete,resourceNames=rhm-remoteresources3-controller;rhm-watch-keeper
+// +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments;deployments/finalizers,verbs=get;list;watch;create
+// +kubebuilder:rbac:groups=apps,namespace=system,resources=deployments;deployments/finalizers,verbs=update;patch;delete,resourceNames=rhm-remoteresources3-controller;rhm-watch-keeper
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=razeedeployments;razeedeployments/finalizers;razeedeployments/status,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=remoteresources3s,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=marketplace.redhat.com,namespace=system,resources=remoteresources3s,verbs=update;patch;delete,resourceNames=child;parent
@@ -334,25 +334,29 @@ func (r *RazeeDeploymentReconciler) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Adding a finalizer to this CR
-	if !utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
-		if err := r.addFinalizer(instance, request.Namespace); err != nil {
-			return reconcile.Result{}, err
-		}
+	/*
+		// Adding a finalizer to this CR
+		if !utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
+			if err := r.addFinalizer(instance, request.Namespace); err != nil {
+				return reconcile.Result{}, err
+			}
 
-		return reconcile.Result{Requeue: true}, nil
-	}
+			return reconcile.Result{Requeue: true}, nil
+		}
+	*/
 
 	// Check if the RazeeDeployment instance is being marked for deletion
-	isMarkedForDeletion := instance.GetDeletionTimestamp() != nil
-	if isMarkedForDeletion {
-		if utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
-			//Run finalization logic for the RAZEE_DEPLOYMENT_FINALIZER.
-			//If it fails, don't remove the finalizer so we can retry during the next reconcile
-			return r.fullUninstall(instance)
+	/*
+		isMarkedForDeletion := instance.GetDeletionTimestamp() != nil
+		if isMarkedForDeletion {
+			if utils.Contains(instance.GetFinalizers(), utils.RAZEE_DEPLOYMENT_FINALIZER) {
+				//Run finalization logic for the RAZEE_DEPLOYMENT_FINALIZER.
+				//If it fails, don't remove the finalizer so we can retry during the next reconcile
+				return r.fullUninstall(instance)
+			}
+			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, nil
-	}
+	*/
 
 	if instance.Spec.TargetNamespace == nil {
 		if instance.Status.RazeeJobInstall != nil {
@@ -1095,11 +1099,22 @@ func (r *RazeeDeploymentReconciler) Reconcile(ctx context.Context, request recon
 	//Only create the parent s3 resource when the razee deployment is enabled
 	if rrs3DeploymentEnabled {
 		var op controllerutil.OperationResult
+
+		// Set the remoteresources3-controller as the controller, since it owns the finalizer
+		rrs3Deployment := &appsv1.Deployment{}
+		err := r.Client.Get(context.TODO(), types.NamespacedName{
+			Name:      utils.RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME,
+			Namespace: request.Namespace,
+		}, rrs3Deployment)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
 		parentRRS3 := r.makeParentRemoteResourceS3(instance)
-		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			op, err = controllerutil.CreateOrUpdate(context.TODO(), r.Client, parentRRS3, func() error {
 				r.updateParentRemoteResourceS3(parentRRS3, instance)
-				return r.factory.SetOwnerReference(instance, parentRRS3)
+				return r.factory.SetControllerReference(rrs3Deployment, parentRRS3)
 			})
 			return err
 		})

--- a/v2/controllers/marketplace/razeedeployment_controller_test.go
+++ b/v2/controllers/marketplace/razeedeployment_controller_test.go
@@ -333,51 +333,6 @@ var _ = Describe("Testing with Ginkgo", func() {
 			),
 			ReconcileStep(opts,
 				ReconcileWithUntilDone(true)),
-
-			/*
-				ListStep(opts,
-					ListWithObj(&marketplacev1alpha1.RemoteResourceS3List{}),
-					ListWithFilter(
-						client.InNamespace(namespace),
-					),
-					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-						list, ok := i.(*marketplacev1alpha1.RemoteResourceS3List)
-						assert.Truef(t, ok, "expected RemoteResourceS3List got type %T", i)
-						assert.Equal(t, 0, len(list.Items))
-					})),
-				ListStep(opts,
-					ListWithObj(&corev1.ConfigMapList{}),
-					ListWithFilter(
-						client.InNamespace(namespace),
-					),
-					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-						list, ok := i.(*corev1.ConfigMapList)
-						assert.Truef(t, ok, "expected configMap list got type %T", i)
-						assert.Equal(t, 0, len(list.Items))
-					})),
-				ListStep(opts,
-					ListWithObj(&corev1.SecretList{}),
-					ListWithFilter(
-						client.InNamespace(namespace),
-					),
-					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-						list, ok := i.(*corev1.SecretList)
-
-						assert.Truef(t, ok, "expected secret list got type %T", i)
-						assert.Equal(t, 0, len(list.Items))
-					})),
-				ListStep(opts,
-					ListWithObj(&appsv1.DeploymentList{}),
-					ListWithFilter(
-						client.InNamespace(namespace),
-					),
-					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-						list, ok := i.(*appsv1.DeploymentList)
-
-						assert.Truef(t, ok, "expected deployment list got type %T", i)
-						assert.Equal(t, 0, len(list.Items))
-					})),
-			*/
 		)
 
 		Eventually(func() []marketplacev1alpha1.RemoteResourceS3 {

--- a/v2/controllers/marketplace/razeedeployment_controller_test.go
+++ b/v2/controllers/marketplace/razeedeployment_controller_test.go
@@ -293,7 +293,6 @@ var _ = Describe("Testing with Ginkgo", func() {
 				ReconcileWithExpectedResults(
 					RequeueResult,
 					RequeueResult,
-					RequeueResult,
 					RequeueAfterResult(time.Second*60)),
 			))
 	})
@@ -334,49 +333,80 @@ var _ = Describe("Testing with Ginkgo", func() {
 			),
 			ReconcileStep(opts,
 				ReconcileWithUntilDone(true)),
-			ListStep(opts,
-				ListWithObj(&marketplacev1alpha1.RemoteResourceS3List{}),
-				ListWithFilter(
-					client.InNamespace(namespace),
-				),
-				ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-					list, ok := i.(*marketplacev1alpha1.RemoteResourceS3List)
-					assert.Truef(t, ok, "expected RemoteResourceS3List got type %T", i)
-					assert.Equal(t, 0, len(list.Items))
-				})),
-			ListStep(opts,
-				ListWithObj(&corev1.ConfigMapList{}),
-				ListWithFilter(
-					client.InNamespace(namespace),
-				),
-				ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-					list, ok := i.(*corev1.ConfigMapList)
-					assert.Truef(t, ok, "expected configMap list got type %T", i)
-					assert.Equal(t, 0, len(list.Items))
-				})),
-			ListStep(opts,
-				ListWithObj(&corev1.SecretList{}),
-				ListWithFilter(
-					client.InNamespace(namespace),
-				),
-				ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-					list, ok := i.(*corev1.SecretList)
 
-					assert.Truef(t, ok, "expected secret list got type %T", i)
-					assert.Equal(t, 0, len(list.Items))
-				})),
-			ListStep(opts,
-				ListWithObj(&appsv1.DeploymentList{}),
-				ListWithFilter(
-					client.InNamespace(namespace),
-				),
-				ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
-					list, ok := i.(*appsv1.DeploymentList)
+			/*
+				ListStep(opts,
+					ListWithObj(&marketplacev1alpha1.RemoteResourceS3List{}),
+					ListWithFilter(
+						client.InNamespace(namespace),
+					),
+					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
+						list, ok := i.(*marketplacev1alpha1.RemoteResourceS3List)
+						assert.Truef(t, ok, "expected RemoteResourceS3List got type %T", i)
+						assert.Equal(t, 0, len(list.Items))
+					})),
+				ListStep(opts,
+					ListWithObj(&corev1.ConfigMapList{}),
+					ListWithFilter(
+						client.InNamespace(namespace),
+					),
+					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
+						list, ok := i.(*corev1.ConfigMapList)
+						assert.Truef(t, ok, "expected configMap list got type %T", i)
+						assert.Equal(t, 0, len(list.Items))
+					})),
+				ListStep(opts,
+					ListWithObj(&corev1.SecretList{}),
+					ListWithFilter(
+						client.InNamespace(namespace),
+					),
+					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
+						list, ok := i.(*corev1.SecretList)
 
-					assert.Truef(t, ok, "expected deployment list got type %T", i)
-					assert.Equal(t, 0, len(list.Items))
-				})),
+						assert.Truef(t, ok, "expected secret list got type %T", i)
+						assert.Equal(t, 0, len(list.Items))
+					})),
+				ListStep(opts,
+					ListWithObj(&appsv1.DeploymentList{}),
+					ListWithFilter(
+						client.InNamespace(namespace),
+					),
+					ListWithCheckResult(func(r *ReconcilerTest, t ReconcileTester, i client.ObjectList) {
+						list, ok := i.(*appsv1.DeploymentList)
+
+						assert.Truef(t, ok, "expected deployment list got type %T", i)
+						assert.Equal(t, 0, len(list.Items))
+					})),
+			*/
 		)
+
+		Eventually(func() []marketplacev1alpha1.RemoteResourceS3 {
+			list := &marketplacev1alpha1.RemoteResourceS3List{}
+			k8sClient.List(context.TODO(), list, client.InNamespace(namespace))
+
+			return list.Items
+		}, timeout, interval).Should(HaveLen(0), "system RemoteResourceS3s should be deleted")
+
+		Eventually(func() []corev1.ConfigMap {
+			list := &corev1.ConfigMapList{}
+			k8sClient.List(context.TODO(), list, client.InNamespace(namespace))
+
+			return list.Items
+		}, timeout, interval).Should(HaveLen(0), "system ConfigMaps should be deleted")
+
+		Eventually(func() []corev1.Secret {
+			list := &corev1.SecretList{}
+			k8sClient.List(context.TODO(), list, client.InNamespace(namespace))
+
+			return list.Items
+		}, timeout, interval).Should(HaveLen(0), "system Secrets should be deleted")
+
+		Eventually(func() []appsv1.Deployment {
+			list := &appsv1.DeploymentList{}
+			k8sClient.List(context.TODO(), list, client.InNamespace(namespace))
+
+			return list.Items
+		}, timeout, interval).Should(HaveLen(0), "system Deployments should be deleted")
 	})
 
 	It("legacy uninstall", func() {

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	/* Resource Names */
+	RHM_CONTROLLER_DEPLOYMENT_NAME         = "redhat-marketplace-controller-manager"
 	RHM_WATCHKEEPER_DEPLOYMENT_NAME        = "rhm-watch-keeper"
 	RHM_REMOTE_RESOURCE_S3_DEPLOYMENT_NAME = "rhm-remoteresources3-controller"
 	RAZEE_DEPLOY_JOB_NAME                  = "razeedeploy-job"


### PR DESCRIPTION
Problem in issue 24954

```
oc delete MarketplaceConfig marketplaceconfig -n openshift-redhat-marketplace
oc delete subscription  redhat-marketplace-operator -n openshift-redhat-marketplace
oc get csv -n openshift-redhat-marketplace --no-headers | awk '/redhat-marketplace-operator/{print $1}'  | xargs oc delete -n openshift-redhat-marketplace csv
```

The lack of ownerref/blockOwnerDeletion on MarketplaceConfig allowed the Controller to be deleted before the finalizer was processed
- via the CSV delete - deletes the Controller Deployment

With this change, this should not happen, and following the deletion commands, we should see no resources stuck with finalizers, and should thus be able to also cleanly delete the namespace
```
oc get marketplaceconfig,meterbase,remoteresources3,razeedeployment
oc delete ns openshift-redhat-marketplace
```


The expectation of the PR is that resources will be more reliably cleaned up without stuck finalizers, and the finalizers that are left to deal with are just MarketplaceConfig and RemoteResourceS3

The one big problem that is left is that, on uninstall (via UI), OLM may delete the controller's service account too early, and the controller loses the rbac permission to be able to remove the finalizer
So, from a user use case, it's still not ok to just go into the UI Installed Operators and just Remove Operator

https://github.com/operator-framework/operator-lifecycle-manager/issues/2235

---

ClusterRegistration

Set the MarketplaceConfig to have a ControllerReference of the redhat-marketplace-controller-manager
- This sets blockOwnerDeletion
- This should allow the finalizer to be deleted by the controller, before the controller itself is allowed to be deleted
- Extend the rbac permissions required to set ControllerReference
---

MarketplaceConfig

- Fix the plurality on rbac for secret
- Extend the rbac permissions required to set ControllerReference

---

MeterBase

- Remove finalizer
- Set SetControllerReference on MeterBase child assets to let GC delete them instead
  - seems like args on manifests.CreateOrUpdateFactoryItemAction doesn't work correctly

---

RazeeDeployment
- Extend the rbac permissions required to set ControllerReference
- Remove finalizer
- Set ControllerReference for RemoteResourceS3 to be the rrs3Deployment
  - With the blockOwnerDeletion, the finalizers will be processed by the rrs3 controller before the controller should be deleted
- Update the test
  - one reconcile/requeue step is removed in the reconciler from no longer adding a finalizer
  - Check that GC has removed resources, instead of the reconciler

---

