### PR TITLE
bugfix: buildah/podman support, dataservice 1.17

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM ${REGISTRY}/data-service-base:1.16-2 as dqlite-lib-builder
+FROM ${REGISTRY}/data-service-base:1.17 as dqlite-lib-builder
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS

--- a/authchecker/v2/Dockerfile
+++ b/authchecker/v2/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     go mod download
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     BINDIR=/usr/local/go/bin make build

--- a/base/Makefile
+++ b/base/Makefile
@@ -9,7 +9,7 @@ IMAGE_REGISTRY ?= public-image-registry.apps-crc.testing/symposium
 
 # Push the docker image
 docker-push:
-	docker push $(IMG)
+	docker push $(17IMG)
 
 docker-build: base data-service
 

--- a/metering/v2/Dockerfile
+++ b/metering/v2/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     go mod download
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     BINDIR=/usr/local/go/bin make build

--- a/reporter/v2/Dockerfile
+++ b/reporter/v2/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     go mod download
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     BINDIR=/usr/local/go/bin make build

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -1,6 +1,5 @@
 comma := ,
-space :=
-space +=
+space := $(subst ,, )
 
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
@@ -173,10 +172,12 @@ ifneq ($(DOCKERBUILDXCACHE),)
 DOCKER_EXTRA_ARGS = --cache-from "type=local,src=$(DOCKERBUILDXCACHE)" --cache-to "type=local,dest=$(DOCKERBUILDXCACHE)" --output "type=image,push=$(IMAGE_PUSH)"
 else
 DOCKER_EXTRA_ARGS =
+ifneq ($(PODMAN),true)
 ifeq ($(IMAGE_PUSH),true)
 DOCKER_BUILD += --push
 else
 DOCKER_BUILD += --load
+endif
 endif
 endif
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     go mod download
@@ -22,7 +22,7 @@ ENV PATH=$PATH:/usr/local/go/bin CGO_ENABLED=0
 
 WORKDIR /src
 
-RUN --mount=target=. \
+RUN --mount=type=bind,source=.,target=/src \
     --mount=type=cache,target=/root/.cache/go-build \
     cd ${path} && \
     BINDIR=/usr/local/go/bin make build

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -146,10 +146,12 @@ ARCH ?= amd64
 
 ifeq ($(BUILDX),true)
 DOCKERCMD=docker buildx
+ifneq ($(PODMAN),true)
 ifeq ($(IMAGE_PUSH),true)
 ARGS=--push
 else
 ARGS=--load
+endif
 endif
 else
 DOCKERCMD=docker


### PR DESCRIPTION
- move dataservice to 1.17
- use explicit `--mount=` args, buildah/podman does not accept the shortcut
- fix the docker-push for base makefile
- fix the space var for utils.Makefile, it would otherwise leave a trailing comma in the arg which buildah/podman would fail on
- do not use a --push or --load with podman, the args are not available

_works for me_ with 
buildah 1.26.1
podman 4.1.0
rhel 9.0