### PR TITLE
bugfix: fix reports; fix operatorgroup filter

### DIFF
--- a/metering/v2/pkg/engine/suite_test.go
+++ b/metering/v2/pkg/engine/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gotidy/ptr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
@@ -64,6 +65,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
+		UseExistingCluster: ptr.Bool(false),
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "..", "v2", "config", "crd", "bases"),
 			filepath.Join("..", "..", "..", "..", "tests", "v2", "testdata"),

--- a/metering/v2/pkg/engine/wire.go
+++ b/metering/v2/pkg/engine/wire.go
@@ -29,20 +29,20 @@ import (
 	rhmclient "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/client"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"k8s.io/client-go/rest"
 )
 
 func NewEngine(
 	ctx context.Context,
 	namespaces types.Namespaces,
 	scheme *runtime.Scheme,
+	restConfig *rest.Config,
 	clientOptions managers.ClientOptions,
 	log logr.Logger,
 	prometheusData *metrics.PrometheusData,
 	statusFlushDuration processors.StatusFlushDuration,
 ) (*Engine, error) {
 	panic(wire.Build(
-		config.GetConfig,
 		managers.ProvideMetadataClientSet,
 		managers.AddIndices,
 		RunnablesSet,

--- a/metering/v2/pkg/engine/wire_gen.go
+++ b/metering/v2/pkg/engine/wire_gen.go
@@ -21,17 +21,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"k8s.io/client-go/rest"
 )
 
 // Injectors from wire.go:
 
-func NewEngine(ctx context.Context, namespaces types.Namespaces, scheme *runtime.Scheme, clientOptions managers.ClientOptions, log logr.Logger, prometheusData *metrics.PrometheusData, statusFlushDuration processors.StatusFlushDuration) (*Engine, error) {
+func NewEngine(ctx context.Context, namespaces types.Namespaces, scheme *runtime.Scheme, restConfig *rest.Config, clientOptions managers.ClientOptions, log logr.Logger, prometheusData *metrics.PrometheusData, statusFlushDuration processors.StatusFlushDuration) (*Engine, error) {
 	namespaceWatcher := filter.ProvideNamespaceWatcher(log)
-	restConfig, err := config.GetConfig()
-	if err != nil {
-		return nil, err
-	}
 	clientset, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err

--- a/metering/v2/pkg/filter/filter.go
+++ b/metering/v2/pkg/filter/filter.go
@@ -58,6 +58,28 @@ func (s FilterRuntimeObjects) Test(obj interface{}) (pass bool, filterIndex int,
 	return
 }
 
+var namespaceFilterType = reflect.TypeOf(&WorkloadNamespaceFilter{})
+
+func (s FilterRuntimeObjects) Types() []reflect.Type {
+	for _, f := range s {
+		if filter, ok := f.(*WorkloadTypeFilter); ok {
+			return filter.gvks
+		}
+	}
+
+	return nil
+}
+
+func (s FilterRuntimeObjects) Namespaces() []string {
+	for _, f := range s {
+		if filter, ok := f.(*WorkloadNamespaceFilter); ok {
+			return filter.namespaces
+		}
+	}
+
+	return nil
+}
+
 func (s FilterRuntimeObjects) String() string {
 	strs := make([]string, 0, len(s))
 	printFilter := func(f FilterRuntimeObject) string {

--- a/metering/v2/pkg/filter/filter_suite_test.go
+++ b/metering/v2/pkg/filter/filter_suite_test.go
@@ -12,16 +12,86 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package filter_test
+package filter
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
+	opsrcv1 "github.com/operator-framework/api/pkg/operators/v1"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	marketplaceredhatcomv1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
+
+	marketplaceredhatcomv1beta1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1beta1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
+
+var cfg *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var scheme *runtime.Scheme
 
 func TestFilter(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Filter Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	os.Setenv("KUBEBUILDER_CONTROLPLANE_START_TIMEOUT", "2m")
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "..", "v2", "config", "crd", "bases"),
+			filepath.Join("..", "..", "..", "..", "tests", "v2", "testdata"),
+		},
+	}
+
+	var err error
+	By("starting env")
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	scheme = provideScheme()
+	// +kubebuilder:scaffold:scheme
+	By("starting client")
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func provideScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(marketplaceredhatcomv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(openshiftconfigv1.AddToScheme(scheme))
+	utilruntime.Must(olmv1.AddToScheme(scheme))
+	utilruntime.Must(opsrcv1.AddToScheme(scheme))
+	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme))
+	utilruntime.Must(marketplaceredhatcomv1beta1.AddToScheme(scheme))
+	return scheme
 }

--- a/metering/v2/pkg/filter/filter_test.go
+++ b/metering/v2/pkg/filter/filter_test.go
@@ -18,6 +18,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("filter", func() {
@@ -63,6 +66,31 @@ var _ = Describe("filter", func() {
 		Expect(pass).To(BeTrue())
 		Expect(i).To(Equal(-1))
 		Expect(err).To(Succeed())
+	})
+})
+
+var _ = Describe("label_filter", func() {
+	var obj client.Object
+
+	BeforeEach(func() {
+		obj = &corev1.Pod{}
+		obj.SetLabels(map[string]string{
+			"app.kubernetes.io/name": "a",
+		})
+	})
+
+	It("should match labels", func() {
+		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app.kubernetes.io/name": "a",
+			},
+		})
+		Expect(err).To(Succeed())
+		sut := &WorkloadLabelFilter{
+			labelSelector: selector,
+		}
+
+		Expect(sut.Filter(obj)).To(BeTrue())
 	})
 })
 

--- a/metering/v2/pkg/filter/lookup.go
+++ b/metering/v2/pkg/filter/lookup.go
@@ -117,6 +117,10 @@ func (s *MeterDefinitionLookupFilter) Matches(obj interface{}) (bool, error) {
 
 	for key, workloadFilters := range s.filters {
 		ans, i, err := workloadFilters.Test(obj)
+		// Don't produce an error if the object gets deleted while testing
+		if err != nil && k8serrors.IsNotFound(err) {
+			return false, nil
+		}
 		if err != nil {
 			filterLogger.Error(err, "filter failed", "key", key, "filters", workloadFilters, "i", i)
 			return false, err

--- a/metering/v2/pkg/filter/lookup.go
+++ b/metering/v2/pkg/filter/lookup.go
@@ -93,7 +93,7 @@ func (s *MeterDefinitionLookupFilter) GetNamespaces() map[string][]reflect.Type 
 		types := f.Types()
 
 		for _, ns := range f.Namespaces() {
-			namespaces[ns] = types
+			namespaces[ns] = append(namespaces[ns], types...)
 		}
 	}
 

--- a/metering/v2/pkg/filter/lookup.go
+++ b/metering/v2/pkg/filter/lookup.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"emperror.dev/errors"
 	"github.com/go-logr/logr"
+	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/common"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1beta1"
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,32 +70,34 @@ func (f *MeterDefinitionLookupFilterFactory) New(
 		log:             f.Log.WithName("meterDefLookupFilter").WithValues("meterdefName", meterdef.Name, "meterdefNamespace", meterdef.Namespace).V(4),
 	}
 
-	ns, err := s.findNamespaces(meterdef)
+	if len(meterdef.Spec.ResourceFilters) == 0 {
+		return nil, errors.New("no resource filters provided")
+	}
+
+	filters, err := s.createFilters(meterdef)
 	if err != nil {
-		s.log.Error(err, "error creating find namespaces")
+		s.log.Error(err, "error creating filters")
 		return nil, err
 	}
 
-	if len(ns) != 0 {
-		filters, err := s.createFilters(meterdef, ns)
-		if err != nil {
-			s.log.Error(err, "error creating filters")
-			return nil, err
-		}
-
-		s.filters = filters
-	} else {
-		// no namespace covered, add no op filters
-		s.filters = []FilterRuntimeObjects{
-			{
-				&FalseFilter{},
-			},
-		}
-	}
-
+	s.filters = filters
 	s.workloads = meterdef.Spec.ResourceFilters
 
 	return s, nil
+}
+
+func (s *MeterDefinitionLookupFilter) GetNamespaces() map[string][]reflect.Type {
+	namespaces := map[string][]reflect.Type{}
+
+	for _, f := range s.filters {
+		types := f.Types()
+
+		for _, ns := range f.Namespaces() {
+			namespaces[ns] = types
+		}
+	}
+
+	return namespaces
 }
 
 func (s *MeterDefinitionLookupFilter) String() string {
@@ -128,124 +129,139 @@ func (s *MeterDefinitionLookupFilter) Matches(obj interface{}) (bool, error) {
 	return false, nil
 }
 
-func (s *MeterDefinitionLookupFilter) findNamespaces(
+func (s *MeterDefinitionLookupFilter) installedByNamespace(
 	instance *v1beta1.MeterDefinition,
-) (namespaces []string, err error) {
-	functionError := errors.NewWithDetails("error with findNamespaces", "meterdef", instance.Name+"/"+instance.Namespace)
-	reqLogger := s.log.WithValues("func", "findNamespaces", "meterdef", instance.Name+"/"+instance.Namespace).V(4)
+	csv *olmv1alpha1.ClusterServiceVersion,
+) ([]string, error) {
+	reqLogger := s.log.WithValues("func", "installedByNamespace", "meterdef", instance.Name+"/"+instance.Namespace).V(4)
 
-	for _, resourceFilter := range instance.Spec.ResourceFilters {
-		if resourceFilter.Namespace == nil {
+	olmGroup, ok := csv.GetAnnotations()["olm.operatorGroup"]
+	if !ok {
+		return []string{instance.GetNamespace()}, nil
+	}
+
+	olmNamespace, ok := csv.GetAnnotations()["olm.operatorNamespace"]
+	if !ok {
+		return []string{instance.GetNamespace()}, nil
+	}
+
+	if ok && olmGroup == "global-operators" && olmNamespace == "openshift-operators" {
+		if olmNamespace == csv.Namespace {
 			reqLogger.Info("operatorGroup is for all namespaces")
-			namespaces = []string{corev1.NamespaceAll}
-			return namespaces, err
+			return []string{corev1.NamespaceAll}, nil
+		} else {
+			reqLogger.Info("operatorGroup is for all namespaces, but csv is a copy")
+			return []string{}, nil
 		}
+	}
 
-		if resourceFilter.Namespace.UseOperatorGroup {
-			reqLogger.Info("operatorGroup vertex")
-			csv := &olmv1alpha1.ClusterServiceVersion{}
+	reqLogger.Info("installedBy not found, falling back to namespace")
+	return []string{instance.GetNamespace()}, nil
+}
 
-			if instance.Spec.InstalledBy == nil {
-				reqLogger.Info("installedBy not provided, falling back to namespace")
+func (s *MeterDefinitionLookupFilter) findNamespacesForResource(
+	instance *v1beta1.MeterDefinition,
+	resourceFilter v1beta1.ResourceFilter,
+) ([]string, error) {
+	functionError := errors.NewWithDetails("error with findNamespaces", "meterdef", instance.Name+"/"+instance.Namespace)
+	reqLogger := s.log.WithValues("func", "findNamespaces", "meterdef", instance.Name+"/"+instance.Namespace)
 
-				return []string{instance.GetNamespace()}, nil
-			}
+	reqLogger.Info("getting namespaces for resource")
 
-			reqLogger.Info("installedBy provided, looking for operatorgroup")
+	namespaces := []string{instance.GetNamespace()}
 
-			err = s.client.Get(context.TODO(), instance.Spec.InstalledBy.ToTypes(), csv)
+	if instance.GetNamespace() == "openshift-operators" {
+		namespaces = []string{corev1.NamespaceAll}
+	}
+
+	if resourceFilter.Namespace == nil {
+		return namespaces, nil
+	}
+
+	if resourceFilter.Namespace.UseOperatorGroup {
+		csv := &olmv1alpha1.ClusterServiceVersion{}
+
+		if instance.Spec.InstalledBy != nil {
+			reqLogger.Info("using installedBy")
+			err := s.client.Get(context.TODO(), instance.Spec.InstalledBy.ToTypes(), csv)
 
 			if err != nil && k8serrors.IsNotFound(err) {
 				reqLogger.Info("installedBy not found, falling back to namespace")
-
-				return []string{instance.GetNamespace()}, nil
+				return namespaces, nil
 			}
 
 			if err != nil {
 				err = errors.Wrap(functionError, "csv not found due to error")
 				reqLogger.Error(err, "installed by is not found")
-
 				return namespaces, err
 			}
 
-			olmNamespacesStr, ok := csv.GetAnnotations()["olm.operatorGroup"]
+			return s.installedByNamespace(instance, csv)
+		}
 
-			if ok && olmNamespacesStr == "" {
-				reqLogger.Info("operatorGroup is for all namespaces")
-				namespaces = []string{corev1.NamespaceAll}
-				return namespaces, nil
-			}
-
-			if ok && olmNamespacesStr != "" {
-				namespaces = strings.Split(olmNamespacesStr, ",")
-				return namespaces, nil
-			}
-
-			olmGroup, ok := csv.GetAnnotations()["olm.operatorGroup"]
-
-			if ok && olmGroup == "global-operators" {
-				olmNamespace, nsOk := csv.GetAnnotations()["olm.operatorNamespace"]
-				if nsOk && olmNamespace == csv.Namespace {
-					reqLogger.Info("operatorGroup is for all namespaces")
-					namespaces = []string{corev1.NamespaceAll}
-				} else {
-					reqLogger.Info("operatorGroup is for all namespaces, but csv is a copy")
-					namespaces = []string{}
-				}
-				return namespaces, err
-			}
-
+		reqLogger.Info("looking for operator group")
+		operatorGroups := &olmv1.OperatorGroupList{}
+		err := s.client.List(context.TODO(), operatorGroups, client.InNamespace(instance.Namespace))
+		if err != nil && k8serrors.IsNotFound(err) {
 			reqLogger.Info("installedBy not found, falling back to namespace")
-			return []string{instance.GetNamespace()}, nil
+			return namespaces, nil
 		}
 
-		if resourceFilter.Namespace.LabelSelector != nil {
-			reqLogger.Info("namespace vertex with filter")
-
-			if resourceFilter.Namespace.LabelSelector == nil {
-				reqLogger.Info("namespace vertex is for all namespaces")
-				break
-			}
-
-			namespaceList := &corev1.NamespaceList{}
-
-			var selector labels.Selector
-			selector, err = metav1.LabelSelectorAsSelector(resourceFilter.Namespace.LabelSelector)
-
-			if err != nil {
-				return namespaces, err
-			}
-
-			err = s.client.List(context.TODO(), namespaceList, client.MatchingLabelsSelector{Selector: selector})
-
-			if err != nil {
-				err = errors.Wrap(functionError, "csv not found")
-				reqLogger.Info("csv not found", "csv", instance.Spec.InstalledBy)
-
-				return namespaces, err
-			}
-
-			for i := range namespaceList.Items {
-				localNs := namespaceList.Items[i].GetName()
-				namespaces = append(namespaces, localNs)
-			}
+		if len(operatorGroups.Items) == 0 || len(operatorGroups.Items) > 1 {
+			return namespaces, nil
 		}
+
+		og := operatorGroups.Items[0]
+		reqLogger.Info("found operator group", "name", og.Name, "namespaces", fmt.Sprintf("%+v", og.Status.Namespaces))
+		return og.Status.Namespaces, nil
 	}
-	return namespaces, err
+
+	if resourceFilter.Namespace.LabelSelector != nil {
+		reqLogger.Info("namespace vertex with label filter")
+		namespaceList := &corev1.NamespaceList{}
+
+		selector, err := metav1.LabelSelectorAsSelector(resourceFilter.Namespace.LabelSelector)
+
+		if err != nil {
+			return namespaces, err
+		}
+
+		err = s.client.List(context.TODO(), namespaceList, client.MatchingLabelsSelector{Selector: selector})
+
+		if err != nil {
+			err = errors.Wrap(functionError, "namespace list error")
+			return namespaces, err
+		}
+
+		for i := range namespaceList.Items {
+			localNs := namespaceList.Items[i].GetName()
+			namespaces = append(namespaces, localNs)
+		}
+
+		return namespaces, nil
+	}
+
+	return namespaces, nil
 }
 
 func (s *MeterDefinitionLookupFilter) createFilters(
 	instance *v1beta1.MeterDefinition,
-	namespaces []string,
 ) ([]FilterRuntimeObjects, error) {
 	// Bottom Up
 	// Start with pods, filter, go to owner. If owner not provided, stop.
 	filters := []FilterRuntimeObjects{}
 
 	for _, filter := range instance.Spec.ResourceFilters {
+		namespaces, err := s.findNamespacesForResource(instance, filter)
+		if err != nil {
+			s.log.Error(err, "namespaces err")
+			return nil, err
+		}
+
+		s.log.Info("filter info", "namespaces", fmt.Sprintf("%+v", namespaces))
+
 		runtimeFilters := []FilterRuntimeObject{&WorkloadNamespaceFilter{namespaces: namespaces}}
 
-		var err error
 		typeFilter := &WorkloadTypeFilter{}
 		switch filter.WorkloadType {
 		case common.WorkloadTypePod:

--- a/metering/v2/pkg/filter/lookup_test.go
+++ b/metering/v2/pkg/filter/lookup_test.go
@@ -1,0 +1,219 @@
+// Copyright 2022 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/common"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1beta1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/client"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/metadata"
+)
+
+var _ = Describe("lookup", func() {
+	var sut *MeterDefinitionLookupFilter
+
+	BeforeEach(func() {
+		restMapper, _ := managers.NewDynamicRESTMapper(cfg)
+		metadataInterface, _ := metadata.NewForConfig(cfg)
+		metadataClient := client.NewMetadataClient(metadataInterface, restMapper)
+
+		sut = &MeterDefinitionLookupFilter{
+			client:    k8sClient,
+			findOwner: client.NewFindOwnerHelper(context.TODO(), metadataClient),
+		}
+		sut.log = logr.Discard()
+	})
+
+	It("should create label filters", func() {
+		sut.MeterDefinition = &v1beta1.MeterDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "foobar",
+			},
+			Spec: v1beta1.MeterDefinitionSpec{
+				ResourceFilters: []v1beta1.ResourceFilter{
+					{
+						Namespace: &v1beta1.NamespaceFilter{
+							UseOperatorGroup: true,
+						},
+						Label: &v1beta1.LabelFilter{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"a.b.c/a": "a",
+								},
+							},
+						},
+						WorkloadType: common.WorkloadTypePod,
+					},
+				},
+			},
+		}
+
+		filters, err := sut.createFilters(sut.MeterDefinition)
+		Expect(err).To(Succeed())
+		Expect(filters).To(HaveLen(1))
+		Expect(filters[0]).To(HaveLen(3))
+		Expect(filters[0].Namespaces()).To(ConsistOf("foobar"))
+		Expect(filters[0].Types()).To(ConsistOf(reflect.TypeOf(&corev1.Pod{})))
+
+		types := []reflect.Type{}
+		for _, filter := range filters[0] {
+			types = append(types, reflect.TypeOf(filter))
+		}
+		Expect(types).To(ConsistOf(
+			reflect.TypeOf(&WorkloadLabelFilter{}),     // should have a label filter
+			reflect.TypeOf(&WorkloadNamespaceFilter{}), // a namespace filter
+			reflect.TypeOf(&WorkloadTypeFilter{}),      // workload type filter
+		))
+
+	})
+
+	It("should find namespace fallbacks properly", func() {
+		sut.MeterDefinition = &v1beta1.MeterDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "openshift-operators",
+			},
+			Spec: v1beta1.MeterDefinitionSpec{
+				ResourceFilters: []v1beta1.ResourceFilter{
+					{
+						Namespace: &v1beta1.NamespaceFilter{
+							UseOperatorGroup: true,
+						},
+						Label: &v1beta1.LabelFilter{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"a.b.c/a": "a",
+								},
+							},
+						},
+						WorkloadType: common.WorkloadTypePod,
+					},
+				},
+			},
+		}
+
+		filters, err := sut.createFilters(sut.MeterDefinition)
+		Expect(err).To(Succeed())
+		Expect(filters).To(HaveLen(1))
+		Expect(filters[0]).To(HaveLen(3))
+		Expect(filters[0].Namespaces()).To(ConsistOf(""))
+		Expect(filters[0].Types()).To(ConsistOf(reflect.TypeOf(&corev1.Pod{})))
+	})
+
+	Context("operator groups", func() {
+		var og = olmv1.OperatorGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "og1",
+				Namespace: "a",
+			},
+			Spec: olmv1.OperatorGroupSpec{
+				TargetNamespaces: []string{
+					"a",
+				},
+			},
+			Status: olmv1.OperatorGroupStatus{
+				Namespaces: []string{"a"},
+			},
+		}
+
+		var pod = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "a",
+				Labels: map[string]string{
+					"a.b.c/a": "a",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "foo",
+						Image: "foo",
+					},
+				},
+			},
+		}
+
+		BeforeEach(func() {
+			k8sClient.Create(context.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a",
+				},
+			})
+			Expect(k8sClient.Create(context.TODO(), &og)).To(Succeed())
+			now := metav1.Now()
+			og.Status = olmv1.OperatorGroupStatus{
+				Namespaces:  []string{"a"},
+				LastUpdated: &now,
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), &og)).To(Succeed())
+			Expect(k8sClient.Create(context.TODO(), &pod)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			k8sClient.Delete(context.TODO(), &og)
+			k8sClient.Delete(context.TODO(), &pod)
+		})
+
+		It("should use operator groups successfully", func() {
+			sut.MeterDefinition = &v1beta1.MeterDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "a",
+				},
+				Spec: v1beta1.MeterDefinitionSpec{
+					ResourceFilters: []v1beta1.ResourceFilter{
+						{
+							Namespace: &v1beta1.NamespaceFilter{
+								UseOperatorGroup: true,
+							},
+							Label: &v1beta1.LabelFilter{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"a.b.c/a": "a",
+									},
+								},
+							},
+							WorkloadType: common.WorkloadTypePod,
+						},
+					},
+				},
+			}
+
+			filters, err := sut.createFilters(sut.MeterDefinition)
+			Expect(err).To(Succeed())
+			Expect(filters).To(HaveLen(1))
+			Expect(filters[0]).To(HaveLen(3))
+			Expect(filters[0].Namespaces()).To(ConsistOf("a"))
+			Expect(filters[0].Types()).To(ConsistOf(reflect.TypeOf(&corev1.Pod{})))
+
+			ans, i, err := filters[0].Test(&pod)
+			Expect(err).To(Succeed())
+			Expect(i).To(Equal(-1))
+			Expect(ans).To(BeTrue())
+		})
+	})
+})

--- a/metering/v2/pkg/filter/namespace_watcher.go
+++ b/metering/v2/pkg/filter/namespace_watcher.go
@@ -15,14 +15,17 @@
 package filter
 
 import (
+	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type NamespaceWatcher struct {
-	namespaces map[client.ObjectKey]interface{}
+	namespaces map[client.ObjectKey]map[string][]reflect.Type
 	watches    []chan interface{}
 	log        logr.Logger
 
@@ -34,10 +37,14 @@ func ProvideNamespaceWatcher(
 	log logr.Logger,
 ) *NamespaceWatcher {
 	return &NamespaceWatcher{
-		namespaces: make(map[client.ObjectKey]interface{}),
+		namespaces: map[client.ObjectKey]map[string][]reflect.Type{},
 		watches:    make([]chan interface{}, 0),
 		log:        log.WithName("namespace-watcher"),
 	}
+}
+
+func (n *NamespaceWatcher) keyFunc(ns string, t reflect.Type) string {
+	return fmt.Sprintf("%s-%s", ns, t.String())
 }
 
 func (n *NamespaceWatcher) alert() {
@@ -57,27 +64,40 @@ func (n *NamespaceWatcher) RegisterWatch(in chan interface{}) error {
 	return nil
 }
 
-func (n *NamespaceWatcher) addNamespace(in client.ObjectKey) (alert bool) {
+func (n *NamespaceWatcher) addNamespace(in client.ObjectKey, nsTypes map[string][]reflect.Type) (alert bool) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
 	before := n.listNamespaces()
 
-	if _, ok := n.namespaces[in]; !ok {
-		n.namespaces[in] = nil
-
+	stored, ok := n.namespaces[in]
+	if !ok {
+		n.namespaces[in] = nsTypes
 		after := n.listNamespaces()
 
-		if !alert && len(before) != len(after) {
+		if !reflect.DeepEqual(before, after) {
 			alert = true
 		}
+
+		return
+	}
+
+	if !reflect.DeepEqual(stored, nsTypes) {
+		n.namespaces[in] = mergeMap(stored, nsTypes)
+		after := n.listNamespaces()
+
+		if !reflect.DeepEqual(before, after) {
+			alert = true
+		}
+		return
 	}
 
 	return
 }
 
-func (n *NamespaceWatcher) AddNamespace(in client.ObjectKey) {
-	alert := n.addNamespace(in)
+func (n *NamespaceWatcher) AddNamespace(in client.ObjectKey, nsTypes map[string][]reflect.Type) {
+	alert := n.addNamespace(in, nsTypes)
+	n.log.Info("adding namespaces", "namespaces", fmt.Sprintf("%+v", n.listNamespaces()), "alert", alert)
 	if alert {
 		n.alert()
 	}
@@ -88,15 +108,11 @@ func (n *NamespaceWatcher) removeNamespace(in client.ObjectKey) (alert bool) {
 	defer n.mu.Unlock()
 
 	before := n.listNamespaces()
+	delete(n.namespaces, in)
+	after := n.listNamespaces()
 
-	if _, ok := n.namespaces[in]; ok {
-		delete(n.namespaces, in)
-
-		after := n.listNamespaces()
-
-		if !alert && len(before) != len(after) {
-			alert = true
-		}
+	if !alert && reflect.DeepEqual(before, after) {
+		alert = true
 	}
 
 	return
@@ -109,27 +125,99 @@ func (n *NamespaceWatcher) RemoveNamespace(in client.ObjectKey) {
 	}
 }
 
-func (n *NamespaceWatcher) listNamespaces() []string {
-	nses := map[string]interface{}{}
+func (n *NamespaceWatcher) listNamespaces() map[string][]reflect.Type {
+	nses := map[string][]reflect.Type{}
 
-	for k := range n.namespaces {
-		nses[k.Namespace] = nil
+	for _, nsToType := range n.namespaces {
+		nses = mergeMap(nses, nsToType)
 	}
 
-	nsesSlice := []string{}
+	if filterTypes, hasAll := nses[corev1.NamespaceAll]; hasAll {
+		filteredNSes := map[string][]reflect.Type{}
+		for ns, filters := range nses {
+			if ns == corev1.NamespaceAll {
+				filteredNSes[ns] = filters
+				continue
+			}
+			result := filterTypeSlice(filters, filterTypes)
+			if len(result) != 0 {
+				filteredNSes[ns] = result
+			}
+		}
 
-	for k := range nses {
-		nsesSlice = append(nsesSlice, k)
+		return filteredNSes
 	}
 
-	return nsesSlice
+	return nses
 }
 
-func (n *NamespaceWatcher) Get() []string {
+func (n *NamespaceWatcher) Get() map[string][]reflect.Type {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
 
 	resp := n.listNamespaces()
-	n.log.Info("list namespaces", "namespaces", resp)
+	n.log.Info("list namespaces", "namespaces", fmt.Sprintf("%v", resp))
 	return resp
+}
+
+func mergeMap(a, b map[string][]reflect.Type) map[string][]reflect.Type {
+	resultMap := map[string][]reflect.Type{}
+
+	for name := range a {
+		resultMap[name] = a[name]
+	}
+
+	for name := range b {
+		v, ok := resultMap[name]
+
+		if ok {
+			resultMap[name] = mergeTypeSlice(v, b[name])
+			continue
+		}
+
+		resultMap[name] = b[name]
+	}
+
+	return resultMap
+}
+
+func mergeTypeSlice(a, b []reflect.Type) []reflect.Type {
+	typeMap := map[reflect.Type]interface{}{}
+	for _, typ := range a {
+		typeMap[typ] = nil
+	}
+	for _, typ := range b {
+		typeMap[typ] = nil
+	}
+
+	merged := []reflect.Type{}
+	for key := range typeMap {
+		merged = append(merged, key)
+	}
+	return merged
+}
+
+func filterTypeSlice(a, filters []reflect.Type) []reflect.Type {
+	typeMap := map[reflect.Type]interface{}{}
+	for _, typ := range a {
+		found := false
+		for _, filter := range filters {
+			if typ == filter {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			continue
+		}
+		typeMap[typ] = nil
+	}
+
+	filtered := []reflect.Type{}
+	for key := range typeMap {
+		filtered = append(filtered, key)
+	}
+	return filtered
+
 }

--- a/metering/v2/pkg/filter/namespace_watcher_test.go
+++ b/metering/v2/pkg/filter/namespace_watcher_test.go
@@ -16,20 +16,24 @@ package filter
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("namespace_watcher", func() {
 	var sut *NamespaceWatcher
-	var item1, item2, item3, item4, item5 client.ObjectKey
+	var item1, item2, item3, item4, item5, item6 client.ObjectKey
 	var alertChan chan interface{}
 	var ctx context.Context
 	var cancel context.CancelFunc
 	var alertCount int
+
+	var types1, types2, types3, types4, types5, types6 map[string][]reflect.Type
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
@@ -39,6 +43,25 @@ var _ = Describe("namespace_watcher", func() {
 		item3 = client.ObjectKey{Namespace: "foo", Name: "pod2"}
 		item4 = client.ObjectKey{Namespace: "foo3", Name: "pod"}
 		item5 = client.ObjectKey{Namespace: "foo4", Name: "pod"}
+		item6 = client.ObjectKey{Namespace: "openshift-operators", Name: "pod"}
+		types1 = map[string][]reflect.Type{
+			"foo": {reflect.TypeOf(&corev1.Pod{})},
+		}
+		types2 = map[string][]reflect.Type{
+			"foo2": {reflect.TypeOf(&corev1.Service{})},
+		}
+		types3 = map[string][]reflect.Type{
+			"foo": {reflect.TypeOf(&corev1.Service{})},
+		}
+		types4 = map[string][]reflect.Type{
+			"foo3": {reflect.TypeOf(&corev1.Pod{})},
+		}
+		types5 = map[string][]reflect.Type{
+			"foo4": {reflect.TypeOf(&corev1.Pod{})},
+		}
+		types6 = map[string][]reflect.Type{
+			"": {reflect.TypeOf(&corev1.Pod{})},
+		}
 		alertChan = make(chan interface{})
 		alertCount = 0
 
@@ -55,9 +78,9 @@ var _ = Describe("namespace_watcher", func() {
 		}()
 
 		sut.RegisterWatch(alertChan)
-		sut.AddNamespace(item1)
-		sut.AddNamespace(item2)
-		sut.AddNamespace(item3)
+		sut.AddNamespace(item1, types1)
+		sut.AddNamespace(item2, types2)
+		sut.AddNamespace(item3, types3)
 	})
 
 	AfterEach(func() {
@@ -65,38 +88,129 @@ var _ = Describe("namespace_watcher", func() {
 	})
 
 	It("should keep track of namespaces based on objects passed to it", func() {
-		Expect(sut.Get()).To(ContainElements("foo", "foo2"))
-		Eventually(func() int {
-			return alertCount
-		}, 5).Should(Equal(2))
-	})
-
-	It("should remove namespaces based on objects passed to it", func() {
-		Expect(sut.Get()).To(ContainElements("foo", "foo2"))
-		sut.RemoveNamespace(item3)
-		Expect(sut.Get()).To(ContainElements("foo", "foo2")) // still have item1 so "foo" should still be there
-		sut.RemoveNamespace(item1)
-		Expect(sut.Get()).To(ContainElements("foo2"))
+		Expect(sut.Get()).To(
+			And(HaveKeyWithValue("foo", ConsistOf(reflect.TypeOf(&corev1.Pod{}), reflect.TypeOf(&corev1.Service{}))),
+				HaveKeyWithValue("foo2", []reflect.Type{reflect.TypeOf(&corev1.Service{})}))) // still have item1 so "foo" should still be there
 		Eventually(func() int {
 			return alertCount
 		}, 5).Should(Equal(3))
+	})
+
+	It("should remove namespaces based on objects passed to it", func() {
+		Expect(sut.Get()).To(And(HaveKey("foo"), HaveKey("foo2")))
+		sut.RemoveNamespace(item3)
+		Expect(sut.Get()).To(
+			And(HaveKeyWithValue("foo", []reflect.Type{reflect.TypeOf(&corev1.Pod{})}),
+				HaveKeyWithValue("foo2", []reflect.Type{reflect.TypeOf(&corev1.Service{})}))) // still have item1 so "foo" should still be there
+		sut.RemoveNamespace(item1)
+		Expect(sut.Get()).To(HaveKey("foo2"))
+		Eventually(func() int {
+			return alertCount
+		}, 5).Should(Equal(5))
 	})
 
 	It("should handle multiple alerts", func() {
 		newAlertChan := make(chan interface{}, 10)
 		defer close(newAlertChan)
 		sut.RegisterWatch(newAlertChan)
-		sut.AddNamespace(item1)
-		sut.AddNamespace(item2)
-		sut.AddNamespace(item3)
+		sut.AddNamespace(item1, types1)
+		sut.AddNamespace(item2, types2)
+		sut.AddNamespace(item3, types3)
 		Eventually(newAlertChan).ShouldNot(Receive())
-		sut.AddNamespace(item4)
+		sut.AddNamespace(item4, types4)
 		Eventually(newAlertChan).Should(Receive(Equal(true)))
-		sut.AddNamespace(item5)
+		sut.AddNamespace(item5, types5)
+
+		Expect(sut.Get()).To(And(HaveKey("foo3"), HaveKey("foo4")))
+
 		Eventually(newAlertChan).Should(Receive(Equal(true)))
 		sut.RemoveNamespace(item5)
 		Eventually(newAlertChan).Should(Receive(Equal(true)))
 		sut.RemoveNamespace(item1)
 		Eventually(newAlertChan).ShouldNot(Receive())
+
+		Expect(sut.Get()).ToNot(And(HaveKey("foo3"), HaveKey("foo4")))
+	})
+
+	It("should handle all-namespaces", func() {
+		By("should handle all namespaces pod")
+		sut.AddNamespace(item1, types1)
+		sut.AddNamespace(item2, types2)
+		sut.AddNamespace(item3, types3)
+		sut.addNamespace(item6, types6)
+		Expect(sut.Get()).To(
+			And(HaveLen(3),
+				HaveKeyWithValue("", []reflect.Type{reflect.TypeOf(&corev1.Pod{})}),
+				HaveKeyWithValue("foo", []reflect.Type{reflect.TypeOf(&corev1.Service{})}),
+				HaveKeyWithValue("foo2", []reflect.Type{reflect.TypeOf(&corev1.Service{})})))
+
+		By("should handle new namespaces for pods with no new change")
+		Expect(sut.addNamespace(item5, types5)).To(BeFalse())
+		Expect(sut.Get()).To(
+			And(HaveLen(3),
+				HaveKeyWithValue("", []reflect.Type{reflect.TypeOf(&corev1.Pod{})}),
+				HaveKeyWithValue("foo", []reflect.Type{reflect.TypeOf(&corev1.Service{})}),
+				HaveKeyWithValue("foo2", []reflect.Type{reflect.TypeOf(&corev1.Service{})})))
+
+		By("removing the all namespaces we get them all")
+		Expect(sut.removeNamespace(item6)).To(BeTrue())
+		Expect(sut.namespaces).To(HaveLen(4))
+		Expect(sut.Get()).To(
+			And(HaveLen(3),
+				HaveKeyWithValue("foo", ConsistOf(reflect.TypeOf(&corev1.Pod{}), reflect.TypeOf(&corev1.Service{}))),
+				HaveKeyWithValue("foo4", []reflect.Type{reflect.TypeOf(&corev1.Pod{})}),
+				HaveKeyWithValue("foo2", []reflect.Type{reflect.TypeOf(&corev1.Service{})})))
+	})
+
+	It("should merge type slices", func() {
+		var a, b []reflect.Type
+		var (
+			rt1, rt2, rt3 reflect.Type = reflect.TypeOf(&corev1.Service{}), reflect.TypeOf(&corev1.Volume{}), reflect.TypeOf(&corev1.Pod{})
+		)
+		a = []reflect.Type{rt1, rt2}
+		b = []reflect.Type{rt3}
+		Expect(mergeTypeSlice(a, b)).To(And(ConsistOf(rt1, rt2, rt3), HaveLen(3)))
+		a = []reflect.Type{rt1, rt2}
+		b = []reflect.Type{rt2}
+		Expect(mergeTypeSlice(a, b)).To(And(ConsistOf(rt1, rt2), HaveLen(2)))
+		a = []reflect.Type{rt3}
+		b = []reflect.Type{rt1, rt2}
+		Expect(mergeTypeSlice(a, b)).To(And(ConsistOf(rt1, rt2, rt3), HaveLen(3)))
+		a = []reflect.Type{rt1}
+		b = []reflect.Type{rt1}
+		Expect(mergeTypeSlice(a, b)).To(And(ConsistOf(rt1), HaveLen(1)))
+	})
+
+	It("should merge map string type slices", func() {
+		var a, b map[string][]reflect.Type
+		var (
+			rt1, rt2, rt3 reflect.Type = reflect.TypeOf(&corev1.Service{}), reflect.TypeOf(&corev1.Volume{}), reflect.TypeOf(&corev1.Pod{})
+		)
+		a = map[string][]reflect.Type{
+			"a": {rt1, rt2},
+			"b": {rt1, rt3},
+		}
+		b = map[string][]reflect.Type{
+			"a": {rt1, rt3},
+			"c": {rt1},
+		}
+		Expect(mergeMap(a, b)).To(
+			And(HaveKeyWithValue("a", ConsistOf(rt1, rt2, rt3)),
+				HaveKeyWithValue("b", ConsistOf(rt1, rt3)),
+				HaveKeyWithValue("c", ConsistOf(rt1)),
+			))
+
+		a = map[string][]reflect.Type{
+			"a": {rt1, rt2},
+			"b": {rt1, rt3},
+		}
+		b = map[string][]reflect.Type{
+			"a": {rt1, rt3},
+			"b": {rt1},
+		}
+		Expect(mergeMap(a, b)).To(
+			And(HaveKeyWithValue("a", ConsistOf(rt1, rt2, rt3)),
+				HaveKeyWithValue("b", ConsistOf(rt1, rt3)),
+			))
 	})
 })

--- a/metering/v2/pkg/processors/mdef_processor.go
+++ b/metering/v2/pkg/processors/mdef_processor.go
@@ -84,6 +84,10 @@ func (w *MeterDefinitionRemovalWatcher) Process(ctx context.Context, d cache.Del
 	return nil
 }
 
+// A MeterDefinition add/update/sync must Resync Objects in case the workloadFilter was updated, in order to match appropriate Objects
+// A MeterDefinition delete must Resync Objects that are associated with the MeterDefinition
+// The store Resync function decides to emit a delta update or delete if a MeterDefinition still matches the Object
+
 func (w *MeterDefinitionRemovalWatcher) onAdd(_ context.Context, d cache.Delta) error {
 	meterdef, ok := d.Object.(*stores.MeterDefinitionExtended)
 
@@ -93,8 +97,8 @@ func (w *MeterDefinitionRemovalWatcher) onAdd(_ context.Context, d cache.Delta) 
 
 	w.log.Info("processing meterdef", "name/namespace", meterdef.Name+"/"+meterdef.Namespace, "namespaces", fmt.Sprintf("%+v", meterdef.Filter.GetNamespaces()))
 	w.nsWatcher.AddNamespace(client.ObjectKeyFromObject(meterdef.MeterDefinition), meterdef.Filter.GetNamespaces())
-	//w.addNamespaces(meterdef)
-	return w.meterDefinitionStore.Resync()
+
+	return w.meterDefinitionStore.SyncByIndex(stores.IndexNamespace, meterdef.GetNamespace())
 }
 
 func (w *MeterDefinitionRemovalWatcher) onDelete(_ context.Context, d cache.Delta) error {
@@ -114,25 +118,7 @@ func (w *MeterDefinitionRemovalWatcher) onDelete(_ context.Context, d cache.Delt
 		return errors.WithStack(err)
 	}
 
-	objects, err := w.meterDefinitionStore.ByIndex(stores.IndexMeterDefinition, key)
-
-	if err != nil {
-		w.log.Error(err, "error finding data")
-		return errors.WithStack(err)
-	}
-
-	for i := range objects {
-		obj := objects[i]
-		w.log.Info("deleting obj", "object", obj)
-		err := w.meterDefinitionStore.Delete(obj)
-
-		if err != nil {
-			w.log.Error(err, "error deleting data")
-			return errors.WithStack(err)
-		}
-	}
-
-	return nil
+	return w.meterDefinitionStore.SyncByIndex(stores.IndexMeterDefinition, key)
 }
 
 func (w *MeterDefinitionRemovalWatcher) onUpdate(_ context.Context, d cache.Delta) error {
@@ -141,35 +127,9 @@ func (w *MeterDefinitionRemovalWatcher) onUpdate(_ context.Context, d cache.Delt
 		return errors.New("encountered unexpected type")
 	}
 
-	w.addNamespaces(meterdef)
+	w.nsWatcher.AddNamespace(client.ObjectKeyFromObject(meterdef.MeterDefinition), meterdef.Filter.GetNamespaces())
 
-	w.log.Info("processing meterdef", "name/namespace", meterdef.Name+"/"+meterdef.Namespace)
-
-	key, err := cache.MetaNamespaceKeyFunc(&meterdef.MeterDefinition)
-
-	if err != nil {
-		w.log.Error(err, "error creating key")
-		return errors.WithStack(err)
-	}
-
-	objects, err := w.meterDefinitionStore.ByIndex(stores.IndexMeterDefinition, key)
-
-	if err != nil {
-		w.log.Error(err, "error finding data")
-		return errors.WithStack(err)
-	}
-
-	for i := range objects {
-		obj := objects[i]
-		err := w.meterDefinitionStore.DeleteFromIndex(obj)
-
-		if err != nil {
-			w.log.Error(err, "error deleting data")
-			return errors.WithStack(err)
-		}
-	}
-
-	return w.meterDefinitionStore.Resync()
+	return w.meterDefinitionStore.SyncByIndex(stores.IndexNamespace, meterdef.GetNamespace())
 }
 
 // Clear Status.WorkloadResources on initial sync such that Status is correct when metric-state starts
@@ -179,11 +139,7 @@ func (w *MeterDefinitionRemovalWatcher) onSync(_ context.Context, d cache.Delta)
 		return errors.New("encountered unexpected type")
 	}
 
-	w.addNamespaces(meterdef)
-
-	return nil
-}
-
-func (w *MeterDefinitionRemovalWatcher) addNamespaces(meterdef *stores.MeterDefinitionExtended) {
 	w.nsWatcher.AddNamespace(client.ObjectKeyFromObject(meterdef.MeterDefinition), meterdef.Filter.GetNamespaces())
+
+	return w.meterDefinitionStore.SyncByIndex(stores.IndexNamespace, meterdef.GetNamespace())
 }

--- a/metering/v2/pkg/processors/status_processor.go
+++ b/metering/v2/pkg/processors/status_processor.go
@@ -29,7 +29,6 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/managers"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -96,8 +95,6 @@ func (u *StatusProcessor) Start(ctx context.Context) error {
 	tick := time.NewTicker(u.flushTime)
 	go func() {
 		defer tick.Stop()
-
-		time.Sleep(wait.Jitter(30*time.Second, 0.01))
 
 		for {
 			u.flush(ctx)

--- a/metering/v2/pkg/server/serve.go
+++ b/metering/v2/pkg/server/serve.go
@@ -64,7 +64,7 @@ type Service struct {
 	engine          *engine.Engine
 	prometheusData  *metrics.PrometheusData
 
-	*isReady
+	*isReady `wire:"-"`
 }
 
 type isReady struct {

--- a/metering/v2/pkg/server/wire.go
+++ b/metering/v2/pkg/server/wire.go
@@ -17,11 +17,11 @@
 package server
 
 import (
-	"github.com/go-logr/logr"
 	"github.com/google/wire"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/internal/metrics"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/pkg/engine"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/pkg/processors"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"time"
 )
 
@@ -32,10 +32,11 @@ func NewServer(
 		engine.NewEngine,
 		ProvideNamespaces,
 		provideScheme,
+		config.GetConfig,
 		getClientOptions,
 		wire.Struct(new(Service), "*"),
 		metrics.ProvidePrometheusData,
-		wire.InterfaceValue(new(logr.Logger), log),
+		wire.Value(log),
 		provideRegistry,
 		provideContext,
 		wire.Value(processors.StatusFlushDuration(time.Minute)),

--- a/metering/v2/pkg/server/wire_gen.go
+++ b/metering/v2/pkg/server/wire_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/internal/metrics"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/pkg/engine"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/pkg/processors"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"time"
 )
 
@@ -23,11 +24,15 @@ func NewServer(opts *Options) (*Service, error) {
 	context := provideContext()
 	namespaces := ProvideNamespaces(opts)
 	scheme := provideScheme()
+	restConfig, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
 	clientOptions := getClientOptions()
 	logger := _wireLoggerValue
 	prometheusData := metrics.ProvidePrometheusData()
 	statusFlushDuration := _wireStatusFlushDurationValue
-	engineEngine, err := engine.NewEngine(context, namespaces, scheme, clientOptions, logger, prometheusData, statusFlushDuration)
+	engineEngine, err := engine.NewEngine(context, namespaces, scheme, restConfig, clientOptions, logger, prometheusData, statusFlushDuration)
 	if err != nil {
 		return nil, err
 	}

--- a/metering/v2/pkg/stores/dictionary.go
+++ b/metering/v2/pkg/stores/dictionary.go
@@ -131,7 +131,7 @@ func (def *MeterDefinitionDictionary) Add(obj interface{}) error {
 		return err
 	}
 
-	def.log.Info("recording obj", "obj", fmt.Sprintf("%+v", obj))
+	def.log.Info("recording obj", "filters", fmt.Sprintf("%+v", addObj.Filter), "obj", fmt.Sprintf("%+v", obj))
 
 	def.Lock()
 	defer def.Unlock()

--- a/metering/v2/pkg/stores/store.go
+++ b/metering/v2/pkg/stores/store.go
@@ -73,7 +73,7 @@ func MeterDefinitionIndexFunc(obj interface{}) ([]string, error) {
 	keys := make([]string, 0, len(v.MeterDefinitions))
 	for i := range v.MeterDefinitions {
 		meterDef := v.MeterDefinitions[i]
-		key, err := cache.MetaNamespaceKeyFunc(&meterDef)
+		key, err := cache.MetaNamespaceKeyFunc(meterDef)
 		if !ok {
 			return nil, errors.Wrap(err, "failed to get obj key")
 		}
@@ -351,6 +351,7 @@ func (s *MeterDefinitionStore) Replace(list []interface{}, _ string) error {
 
 // Resync implements the Resync method of the store interface.
 func (s *MeterDefinitionStore) Resync() error {
+	s.List()
 	return nil
 }
 

--- a/metering/v2/test/engine_testcase1/file.go
+++ b/metering/v2/test/engine_testcase1/file.go
@@ -36,4 +36,5 @@ var (
 	ServicePrometheus *unstructured.Unstructured = testCase1.MustGetUnstructured("service-ibm-licensing-service-prometheus.yaml")
 	MDefExample       *unstructured.Unstructured = testCase1.MustGetUnstructured("mdef-pod.yaml")
 	Pod               *unstructured.Unstructured = testCase1.MustGetUnstructured("pod.yaml")
+	OperatorGroup     *unstructured.Unstructured = testCase1.MustGetUnstructured("operatorgroup.yaml")
 )

--- a/metering/v2/test/engine_testcase1/operatorgroup.yaml
+++ b/metering/v2/test/engine_testcase1/operatorgroup.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ibm-common-services-operators
+  namespace: ibm-common-services
+spec:
+  targetNamespaces:
+    - ibm-common-services
+status:
+  namespaces:
+    - ibm-common-services

--- a/reporter/v2/pkg/reporter/reporter.go
+++ b/reporter/v2/pkg/reporter/reporter.go
@@ -169,9 +169,11 @@ func (r *MarketplaceReporter) CollectMetrics(ctxIn context.Context) (map[string]
 
 	logger.Info("sending queries")
 
-	r.ProduceMeterDefinitions(
-		r.meterDefinitions,
-		meterDefsChan)
+	err := r.ProduceMeterDefinitions(r.meterDefinitions, meterDefsChan)
+	if err != nil {
+		logger.Error(err, "error occurred processing")
+		errorsChan <- err
+	}
 
 	logger.Info("sending queries done")
 	close(meterDefsChan)

--- a/v2/assets/metric-state/deployment.yaml
+++ b/v2/assets/metric-state/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               memory: 80Mi
             limits:
               cpu: 100m
-              memory: 130Mi
+              memory: 200Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -396,6 +396,13 @@ rules:
       - watch
       - list
   - nonResourceURLs:
+    - /api/v1/query
+    - /api/v1/query_range
+    - /api/v1/targets
+    verbs:
+    - create
+    - get
+  - nonResourceURLs:
     - /dataservice.v1.fileserver.FileServer/*
     verbs:
     - create

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -396,13 +396,6 @@ rules:
       - watch
       - list
   - nonResourceURLs:
-    - /api/v1/query
-    - /api/v1/query_range
-    - /api/v1/targets
-    verbs:
-    - create
-    - get
-  - nonResourceURLs:
     - /dataservice.v1.fileserver.FileServer/*
     verbs:
     - create
@@ -431,6 +424,13 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operatorgroups
+    verbs:
+      - get
+      - list
   - apiGroups:
       - monitoring.coreos.com
     resources:

--- a/v2/config/rbac/classic/role.yaml
+++ b/v2/config/rbac/classic/role.yaml
@@ -466,3 +466,11 @@ rules:
       - update
       - patch
       - watch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/v2/config/rbac/classic/role_binding.yaml
+++ b/v2/config/rbac/classic/role_binding.yaml
@@ -132,6 +132,20 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: reporter-cluster-monitoring-binding
+  namespace: system
+subjects:
+- kind: ServiceAccount
+  name: reporter
+  namespace: system
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: mteric-state-mdef-editor-binding
   namespace: openshift-config
 subjects:

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -65,6 +65,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - get

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -271,6 +271,7 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=prometheuses,verbs=update;patch;delete,resourceNames=rhm-marketplaceconfig-meterbase
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=servicemonitors,verbs=update;patch;delete,resourceNames=rhm-metric-state;kube-state-metrics;rhm-prometheus-meterbase;redhat-marketplace-kubelet;prometheus-user-workload;redhat-marketplace-kube-state-metrics
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="operators.coreos.com",resources=operatorgroups,verbs=get;list
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=update;patch;delete,resourceNames=rhm-meter-report-upload
 // +kubebuilder:rbac:urls=/metrics,verbs=get

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -274,6 +274,9 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="operators.coreos.com",resources=operatorgroups,verbs=get;list
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=batch;extensions,namespace=system,resources=cronjobs,verbs=update;patch;delete,resourceNames=rhm-meter-report-upload
+
+// The operator SA token is used by rhm-prom ServiceMonitors. Must be able to scrape metrics.
+// +kubebuilder:rbac:groups="",resources=nodes/metrics,verbs=get
 // +kubebuilder:rbac:urls=/metrics,verbs=get
 
 // Reconcile reads that state of the cluster for a MeterBase object and makes changes based on the state read

--- a/v2/pkg/prometheus/prometheus_client.go
+++ b/v2/pkg/prometheus/prometheus_client.go
@@ -136,20 +136,6 @@ func providePrometheusAPIForReporter(
 
 		localClient := v1.NewAPI(client)
 		return localClient, nil
-	} else {
-		if setup.PromService == nil {
-			return nil, errors.New("prom service is not provided")
-		}
-		if setup.PromPort == nil {
-			return nil, errors.New("prom port is not provided")
-		}
-	}
-
-	if setup.PromService == nil {
-		return nil, errors.New("prom service is not provided")
-	}
-	if setup.PromPort == nil {
-		return nil, errors.New("prom port is not provided")
 	}
 
 	if setup.PromService == nil {
@@ -170,6 +156,10 @@ func providePrometheusAPIForReporter(
 			return nil, err
 		}
 		auth = fmt.Sprintf(string(content))
+	}
+
+	if auth == "" {
+		return nil, errors.New("failed to read a token, no TokenFilePath provided")
 	}
 
 	conf, err := NewSecureClient(&PrometheusSecureClientConfig{


### PR DESCRIPTION
What's changed:

* Added missing role to marketplace-reporter service account
* Adjusted filtering to properly filter the operator group
  * Lots of tests added
* Namespace tracking enhancments
  * Tracking namespaces expanded to handle the reflector type (pod, service, etc)
  * If an all namespaces filter is detected for a type, it supersedes all other reflectors i.e. 1 global pod reflector vs 1 global pod reflect & namespace reflectors
  * Tons of testing to test different scenarios


