### PR TITLE
fix: report uploader

### DIFF
--- a/reporter/v2/pkg/reporter/upload_task.go
+++ b/reporter/v2/pkg/reporter/upload_task.go
@@ -91,8 +91,10 @@ func (r *UploadTask) RunReport(ctx context.Context, report *marketplacev1alpha1.
 		return err
 	}
 
-	if err = r.deleteFile(ctx, file); err != nil {
-		logger.Error(err, "failed to delete metadata")
+	if success {
+		if err = r.deleteFile(ctx, file); err != nil {
+			logger.Error(err, "failed to delete metadata")
+		}
 	}
 
 	return nil

--- a/reporter/v2/pkg/reporter/upload_task.go
+++ b/reporter/v2/pkg/reporter/upload_task.go
@@ -93,8 +93,10 @@ func (r *UploadTask) RunReport(ctx context.Context, report *marketplacev1alpha1.
 
 	if success {
 		if err = r.deleteFile(ctx, file); err != nil {
-			logger.Error(err, "failed to delete metadata")
+			logger.Error(err, "failed to delete file from dataservice")
 		}
+	} else {
+		logger.Info("Upload to backend failed, skipping file deletion from dataservice")
 	}
 
 	return nil


### PR DESCRIPTION
Ticket:
https://zenhub.ibm.com/workspaces/symposium-workflow-5c49e21b79c5ae72931da0d6/issues/symposium/track-and-plan/25629

Changes:
- Updated upload task to delete the file from DataService only when the backend upload was successful.