### PR TITLE
fix: reconcile system meterdefs

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -29,6 +29,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/common"
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1beta1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/config"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/manifests"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/prometheus"
@@ -263,7 +264,7 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				OwnerType:    &marketplacev1alpha1.MeterBase{}},
 			builder.WithPredicates(namespacePredicate)).
 		Watches(
-			&source.Kind{Type: &marketplacev1alpha1.MeterDefinition{}},
+			&source.Kind{Type: &v1beta1.MeterDefinition{}},
 			&handler.EnqueueRequestForOwner{
 				IsController: true,
 				OwnerType:    &marketplacev1alpha1.MeterBase{}},

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -127,6 +127,11 @@ const (
 	FileServerAudience   = "rhm-meterdefinition-file-server.openshift-redhat-marketplace.svc"
 	ProductionURL        = "https://marketplace.redhat.com"
 	StageURL             = "https://sandbox.marketplace.redhat.com"
+
+	UserWorkloadMonitoringMeterdef    = "prometheus-user-workload-uptime"
+	MeterReportJobFailedMeterdef      = "rhm-meter-report-job-failed"
+	MetricStateUptimeMeterdef         = "rhm-metric-state-uptime"
+	PrometheusMeterbaseUptimeMeterdef = "rhm-prometheus-meterbase-uptime"
 )
 
 var (


### PR DESCRIPTION
**Ticket:**
https://zenhub.ibm.com/workspaces/symposium-workflow-5c49e21b79c5ae72931da0d6/issues/symposium/track-and-plan/23520

**Changes:**
- Updated meterbase_controller to include a watch on System MeterDefinitions, and it reconciles when they are updated or deleted.