### PR TITLE
Update reporter flow

### DIFF
--- a/reporter/v2/pkg/reporter/upload_task.go
+++ b/reporter/v2/pkg/reporter/upload_task.go
@@ -91,8 +91,12 @@ func (r *UploadTask) RunReport(ctx context.Context, report *marketplacev1alpha1.
 		return err
 	}
 
-	if err = r.deleteFile(ctx, file); err != nil {
-		logger.Error(err, "failed to delete metadata")
+	if success {
+		if err = r.deleteFile(ctx, file); err != nil {
+			logger.Error(err, "failed to delete file from dataservice")
+		}
+	} else {
+		logger.Info("Upload to backend failed, skipping file deletion from dataservice")
 	}
 
 	return nil


### PR DESCRIPTION
**Tickets:**
https://zenhub.ibm.com/workspaces/symposium-workflow-5c49e21b79c5ae72931da0d6/issues/symposium/track-and-plan/25629
https://zenhub.ibm.com/workspaces/symposium-workflow-5c49e21b79c5ae72931da0d6/issues/symposium/track-and-plan/25827


**Changes:**
- Updated report uploader logic to solely depend on the status of the upload POST call
- Removed `statusRequest` function and other relevant components
- Updated/fixed unit tests
- Discussed with Mari, and removed conflict checks and retry checks from `checkError` logic 
- Updated upload task to delete the file from DataService only when the backend upload is successful.