### PR TITLE
fix: default to 24 retries

### DIFF
--- a/reporter/v2/cmd/reporter/reconciler/reconcile.go
+++ b/reporter/v2/cmd/reporter/reconciler/reconcile.go
@@ -135,7 +135,7 @@ func init() {
 	ReconcileCmd.Flags().BoolVar(&local, "local", false, "run locally")
 	ReconcileCmd.Flags().BoolVar(&upload, "upload", true, "to upload the payload")
 	ReconcileCmd.Flags().StringVar(&isDisconnected, "isDisconnected", os.Getenv("IS_DISCONNECTED"), "is the reporter running in a disconnected environment")
-	ReconcileCmd.Flags().IntVar(&retry, "retry", 3, "number of retries")
+	ReconcileCmd.Flags().IntVar(&retry, "retry", 24, "number of retries")
 	ReconcileCmd.Flags().StringVar(&deployedNamespace, "deployedNamespace", "openshift-redhat-marketplace", "namespace where the rhm operator is deployed")
 
 	ReconcileCmd.Flags().StringVar(&prometheusService, "prometheus-service", "rhm-prometheus-meterbase", "token file for the data service")

--- a/reporter/v2/cmd/reporter/report/report.go
+++ b/reporter/v2/cmd/reporter/report/report.go
@@ -117,7 +117,7 @@ func init() {
 	ReportCmd.Flags().StringVar(&localFilePath, "localFilePath", ".", "target to upload to")
 	ReportCmd.Flags().BoolVar(&local, "local", false, "run locally")
 	ReportCmd.Flags().BoolVar(&upload, "upload", true, "to upload the payload")
-	ReportCmd.Flags().IntVar(&retry, "retry", 3, "number of retries")
+	ReportCmd.Flags().IntVar(&retry, "retry", 24, "number of retries")
 	ReportCmd.Flags().StringVar(&reporterSchema, "reporterSchema", "v1alpha1", "reporter version schema to write")
 	ReportCmd.Flags().StringVar(&deployedNamespace, "deployedNamespace", "openshift-redhat-marketplace", "namespace where the rhm operator is deployed")
 }

--- a/reporter/v2/pkg/reporter/reconcile_task.go
+++ b/reporter/v2/pkg/reporter/reconcile_task.go
@@ -234,7 +234,7 @@ func (r *ReconcileTask) CanRunGenericUpload(ctx context.Context) (bool, ReportSk
 	return true, SkipEmpty
 }
 
-const maxUploadAttempts = 3
+const maxUploadAttempts = 24
 
 // IsDisconnected defaults to false
 func (r *ReconcileTask) CanRunUploadReportTask(ctx context.Context, report marketplacev1alpha1.MeterReport) (ReportSkipReason, bool) {

--- a/reporter/v2/pkg/reporter/reconcile_task_test.go
+++ b/reporter/v2/pkg/reporter/reconcile_task_test.go
@@ -201,7 +201,7 @@ var _ = Describe("reconcile_task", func() {
 			Expect(reason).To(Equal(SkipDisconnected))
 
 			sut.Config.IsDisconnected = false
-			report.Status.RetryUpload = 3
+			report.Status.RetryUpload = 24
 
 			reason, ok = sut.CanRunUploadReportTask(nil, report)
 			Expect(ok).To(BeFalse())


### PR DESCRIPTION
- We run the cronjob hourly
- Set the retry limit to 24 to allow 1 full day of retries