### PR TITLE
build should use latest stable go

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM ${REGISTRY}/data-service-base:1.16-2 as dqlite-lib-builder
+FROM ${REGISTRY}/data-service-base:1.17 as dqlite-lib-builder
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS

--- a/base/base.Dockerfile
+++ b/base/base.Dockerfile
@@ -7,7 +7,7 @@ ARG ARCH=${TARGETARCH}
 ARG OS=${TARGETOS:-linux}
 ENV VERSION=${GO_VERSION} OS=${OS} ARCH=${ARCH}
 
-RUN dnf -y install git make yum gzip \
+RUN dnf -y install git make yum gzip jq \
   && dnf -y update \
   && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
   && yum -y clean all \
@@ -15,7 +15,9 @@ RUN dnf -y install git make yum gzip \
   && rm -rf /var/cache/yum
 
 
-RUN curl -o go.tar.gz https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
+RUN FOUND_VER=$(curl -s 'https://go.dev/dl/?mode=json' -H 'Accept: application/json' | jq -r '.[].version|select(contains(env.VERSION))') && \
+  echo "go major version: $VERSION, found latest stable minor version: $FOUND_VER" && \
+  curl -L -o go.tar.gz https://go.dev/dl/$FOUND_VER.$OS-$ARCH.tar.gz && \
   rm -rf /usr/local/go && \
   sha256sum go.tar.gz && \
   tar -C /usr/local -xzf go.tar.gz && \

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 ENV GO_VERSION=${GO_VERSION} OS=linux ARCH=${TARGETARCH}
 
 RUN apt update -y && \
-    apt install -y software-properties-common apt-utils git build-essential dh-autoreconf pkg-config libuv1-dev libsqlite3-dev liblz4-1 liblz4-dev wget
+    apt install -y software-properties-common apt-utils git build-essential dh-autoreconf pkg-config libuv1-dev libsqlite3-dev liblz4-1 liblz4-dev wget jq
 
 WORKDIR /opt/raft
 
@@ -31,7 +31,9 @@ RUN git clone --depth 1 -b $DQLITE_VERSION https://github.com/canonical/dqlite.g
 
 WORKDIR /opt/golang
 
-RUN wget -qO./go.tar.gz https://dl.google.com/go/go$GO_VERSION.$OS-$TARGETARCH.tar.gz && \
+RUN FOUND_VER=$(wget -cq --header='Accept: application/json' 'https://go.dev/dl/?mode=json' -O - | jq -r '.[].version|select(contains(env.GO_VERSION))') && \
+    echo "go major version: $GO_VERSION, found latest stable minor version: $FOUND_VER" && \
+    wget -qO./go.tar.gz https://dl.google.com/go/$FOUND_VER.$OS-$TARGETARCH.tar.gz && \
     rm -rf /usr/local/go && \
     tar -C /usr/local -xzf go.tar.gz
 

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -11,6 +11,7 @@ export VERSION
 export TAG
 
 BINDIR ?= ./bin
+# GO_VERSION can be major version only, latest stable minor version will be retrieved by base.Dockerfile
 GO_VERSION ?= 1.17
 ARCHS ?= amd64 ppc64le s390x arm64
 BUILDX ?= true


### PR DESCRIPTION
For 
https://github.ibm.com/redhat-marketplace/psirt-automation/issues/1393
https://github.ibm.com/redhat-marketplace/psirt-automation/issues/1394

This supersedes #333 

- The workflows automatically retrieve the latest stable minor version with a given major version, the updates in that PR are unnecessary
- The base.Dockerfile is what actually gets used in the image, which was ultimately just 1.17.0 as set in the utils.Makefile
- This update will automatically pull the latest minor version if only major version is given, but GO_VERSION should also be set to a specific minor