### PR TITLE
fix: ownerref and npe

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -312,6 +312,15 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 		return result.Return()
 	}
 
+	// Remove finalizer used by previous versions, ownerref gc deletion is used for cleanup
+	if controllerutil.ContainsFinalizer(instance, utils.CONTROLLER_FINALIZER) {
+		controllerutil.RemoveFinalizer(instance, utils.CONTROLLER_FINALIZER)
+		if err := r.Client.Update(context.TODO(), instance); err != nil {
+			reqLogger.Error(err, "Failed to update MeterBase")
+			return reconcile.Result{}, err
+		}
+	}
+
 	// if instance.Enabled == false
 	// return do nothing
 	if !instance.Spec.Enabled {

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -277,6 +277,15 @@ func (r *RazeeDeploymentReconciler) Reconcile(ctx context.Context, request recon
 		return reconcile.Result{}, err
 	}
 
+	// Remove finalizer used by previous versions, ownerref gc deletion is used for cleanup
+	if controllerutil.ContainsFinalizer(instance, utils.CONTROLLER_FINALIZER) {
+		controllerutil.RemoveFinalizer(instance, utils.CONTROLLER_FINALIZER)
+		if err := r.Client.Update(context.TODO(), instance); err != nil {
+			reqLogger.Error(err, "Failed to update RazeeDeployment")
+			return reconcile.Result{}, err
+		}
+	}
+
 	// if not enabled then exit
 	if !instance.Spec.Enabled {
 		reqLogger.Info("Razee not enabled")

--- a/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/v2/controllers/marketplace/razeedeployment_controller.go
@@ -278,8 +278,8 @@ func (r *RazeeDeploymentReconciler) Reconcile(ctx context.Context, request recon
 	}
 
 	// Remove finalizer used by previous versions, ownerref gc deletion is used for cleanup
-	if controllerutil.ContainsFinalizer(instance, utils.CONTROLLER_FINALIZER) {
-		controllerutil.RemoveFinalizer(instance, utils.CONTROLLER_FINALIZER)
+	if controllerutil.ContainsFinalizer(instance, utils.RAZEE_DEPLOYMENT_FINALIZER) {
+		controllerutil.RemoveFinalizer(instance, utils.RAZEE_DEPLOYMENT_FINALIZER)
 		if err := r.Client.Update(context.TODO(), instance); err != nil {
 			reqLogger.Error(err, "Failed to update RazeeDeployment")
 			return reconcile.Result{}, err

--- a/v2/pkg/marketplace/marketplace_client.go
+++ b/v2/pkg/marketplace/marketplace_client.go
@@ -397,6 +397,10 @@ func (m *MarketplaceClient) getClusterObjID(account *MarketplaceClientAccount) (
 
 	logger.Info("get cluster objId query", "query", u.String())
 	resp, err := m.httpClient.Get(u.String())
+	if err != nil {
+		return "", err
+	}
+
 	clusterDef, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
- handle err in marketplace client, if request fails, it leads to an NPE
- add a remove finalizer check for meterbase and razeedeployment
  - we no longer use the finalizer for cleanup of these objects, and use the ownerRef to have kube GC them
  - in an upgrade situation, if the finalizer was set by an older version, it would cause cleanup to fail with stuck finalizers (ex; upgrade 2.7.0 -> 2.7.1 -> uninstall)