### PR TITLE
chore: build grpc-health-probe on current golang version

### DIFF
--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -39,3 +39,5 @@ RUN FOUND_VER=$(wget -cq --header='Accept: application/json' 'https://go.dev/dl/
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_VERSION}/grpc_health_probe-$TARGETOS-$TARGETARCH && \
     chmod +x /bin/grpc_health_probe
+
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_VERSION}


### PR DESCRIPTION
also build the grpc-health-probe in the dqlite-lib-builder image on our current version of golang, in case we need to ship a CVE fix
we can choose which one we copy later in the airgap Dockerfile