### PR TITLE
fix: use self-built grpc-health-probe

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -72,7 +72,12 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=dqlite-lib-builder /go/bin/main /opt/main
-COPY --from=dqlite-lib-builder /bin/grpc_health_probe /bin/grpc_health_probe
+
+# from https://github.com/grpc-ecosystem/grpc-health-probe/releases
+# COPY --from=dqlite-lib-builder /bin/grpc_health_probe /bin/grpc_health_probe
+
+# built using latest golang on dqlite-lib-builder
+COPY --from=dqlite-lib-builder /go/bin/grpc-health-probe /bin/grpc_health_probe
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -39,3 +39,5 @@ RUN FOUND_VER=$(wget -cq --header='Accept: application/json' 'https://go.dev/dl/
 
 RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_VERSION}/grpc_health_probe-$TARGETOS-$TARGETARCH && \
     chmod +x /bin/grpc_health_probe
+
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_VERSION}


### PR DESCRIPTION
with untimely releases of grpc-health-probe release binary for CVEs, instead build/install using our (latest) version of golang 