### PR TITLE
Release/2.9.1

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -79,8 +79,8 @@ const (
 	DEFAULT_CONFIGMAP_RELOAD       = "jimmidyson/configmap-reload:v0.3.0"
 	RELATED_IMAGE_PROM_SERVER      = "RELATED_IMAGE_PROM_SERVER"
 	RELATED_IMAGE_CONFIGMAP_RELOAD = "RELATED_IMAGE_CONFIGMAP_RELOAD"
-	
-	PROM_DEP_NEW_WARNING_MSG = "Use of redhat-marketplace-operator Prometheus is deprecated. Configuration of user workload monitoring is required https://marketplace.redhat.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
+
+	PROM_DEP_NEW_WARNING_MSG     = "Use of redhat-marketplace-operator Prometheus is deprecated. Configuration of user workload monitoring is required https://marketplace.redhat.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
 	PROM_DEP_UPGRADE_WARNING_MSG = "Use of redhat-marketplace-operator Prometheus is deprecated, and will be removed next release. Configure user workload monitoring https://marketplace.redhat.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
 )
 
@@ -483,7 +483,6 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 			Do(r.checkUWMDefaultStorageClassPrereq(instance)...),
 			Do(r.installPrometheusServingCertsCABundle()...),
 			Do(r.installMetricStateDeployment(instance, userWorkloadMonitoringEnabled)...),
-			Do(r.installUserWorkloadMonitoring(instance)...),
 		); !result.Is(Continue) {
 			if result.Is(Error) {
 				reqLogger.Error(result, "error in reconcile")
@@ -492,6 +491,10 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 			reqLogger.Info("returning result from openshift provides prometheus", "result", *result)
 			return result.Return()
+		}
+
+		if err := r.installUserWorkloadMonitoring(instance); err != nil {
+			return reconcile.Result{}, err
 		}
 
 		promStsNamespacedName = types.NamespacedName{
@@ -505,7 +508,7 @@ func (r *MeterBaseReconciler) Reconcile(ctx context.Context, request reconcile.R
 		// Decide by whether prometheus-operator deployment already exists
 		prometheusOperatorDeployment := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: utils.METERBASE_PROMETHEUS_OPERATOR_NAME, Namespace: request.Namespace}, prometheusOperatorDeployment)
-	    if err != nil && !kerrors.IsNotFound(err) {
+		if err != nil && !kerrors.IsNotFound(err) {
 			reqLogger.Error(err, "Failed to get prometheus-operator deployment")
 			return reconcile.Result{}, err
 		} else if kerrors.IsNotFound(err) { // Deployment does not exist, assume new installation
@@ -1043,34 +1046,22 @@ func (r *MeterBaseReconciler) checkUWMDefaultStorageClassPrereq(
 		})}
 }
 
-func (r *MeterBaseReconciler) installUserWorkloadMonitoring(
-	instance *marketplacev1alpha1.MeterBase,
-) []ClientAction {
-	serviceMonitor := &monitoringv1.ServiceMonitor{}
-	meterDefinition := &marketplacev1beta1.MeterDefinition{}
+// Install the and MeterDefinition to monitor & report UserWorkloadMonitoring uptime
+func (r *MeterBaseReconciler) installUserWorkloadMonitoring(instance *marketplacev1alpha1.MeterBase) error {
 
-	args := manifests.CreateOrUpdateFactoryItemArgs{
-		Owner:   instance,
-		Patcher: r.patcher,
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		return r.factory.UserWorkloadMonitoringServiceMonitor()
+	}); err != nil {
+		return err
 	}
 
-	actions := []ClientAction{
-		manifests.CreateOrUpdateFactoryItemAction(
-			serviceMonitor,
-			func() (client.Object, error) {
-				return r.factory.UserWorkloadMonitoringServiceMonitor()
-			},
-			args,
-		),
-		manifests.CreateOrUpdateFactoryItemAction(
-			meterDefinition,
-			func() (client.Object, error) {
-				return r.factory.UserWorkloadMonitoringMeterDefinition()
-			},
-			args,
-		),
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		return r.factory.UserWorkloadMonitoringMeterDefinition()
+	}); err != nil {
+		return err
 	}
-	return actions
+
+	return nil
 }
 
 func (r *MeterBaseReconciler) uninstallPrometheusOperator(

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -1017,9 +1017,11 @@ func (r *MeterBaseReconciler) installMetricStateDeployment(
 		actions = append(actions,
 			HandleResult(
 				GetAction(types.NamespacedName{Namespace: kubeStateMetricsServiceMonitor.Namespace, Name: kubeStateMetricsServiceMonitor.Name}, kubeStateMetricsServiceMonitor),
+				OnNotFound(ContinueResponse()),
 				OnContinue(DeleteAction(kubeStateMetricsServiceMonitor))),
 			HandleResult(
 				GetAction(types.NamespacedName{Namespace: kubeletServiceMonitor.Namespace, Name: kubeletServiceMonitor.Name}, kubeletServiceMonitor),
+				OnNotFound(ContinueResponse()),
 				OnContinue(DeleteAction(kubeletServiceMonitor))),
 		)
 	}

--- a/v2/version/version.go
+++ b/v2/version/version.go
@@ -14,5 +14,5 @@
 
 package version
 
-const Version = "2.9.0"
-const LastVersion = "2.8.2"
+const Version = "2.9.1"
+const LastVersion = "2.9.0"


### PR DESCRIPTION
- installUserWorkloadMonitoring func was failing on CreateOrUpdateFactoryItemAction via updateWithPatchAction. This was a problem encountered on v4.11, which is the motivation to remove the use of reconcileutils . Back porting the factory CreateOrUpdate func to handle the error with meterbase.
- correct the missing OnNotFound(ContinueResponse()) for the service monitor installation


error in v2.9.0

```
023-01-20T14:26:23.991Z	ERROR	error from action	{"file": "/src/v2/pkg/utils/reconcileutils/reconcile.go:412", "action": "Do", "error": "error while updating with patch: meterdefinitions.marketplace.redhat.com \"prometheus-user-workload-uptime\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update", "errorVerbose": "meterdefinitions.marketplace.redhat.com \"prometheus-user-workload-uptime\" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update\nerror while updating with patch\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*updateWithPatchAction).Exec\n\t/src/v2/pkg/utils/reconcileutils/updateAction.go:181\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*call).Exec\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:64\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*handleResult).Exec\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:341\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*do).Exec\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:101\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*ClientCommand).Do\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:412\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/manifests.(*createOrUpdateFactoryItemAction).Exec\n\t/src/v2/pkg/manifests/action.go:134\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*do).Exec\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:101\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*do).Exec\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:101\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils/reconcileutils.(*ClientCommand).Do\n\t/src/v2/pkg/utils/reconcileutils/reconcile.go:412\ngithub.com/redhat-marketplace/redhat-marketplace-operator/v2/controllers/marketplace.(*MeterBaseReconciler).Reconcile\n\t/src/v2/controllers/marketplace/meterbase_controller.go:482\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1594"}
```