### PR TITLE
deployment controller

### DIFF
--- a/deployer/v2/config/rbac/role.yaml
+++ b/deployer/v2/config/rbac/role.yaml
@@ -113,6 +113,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get
@@ -140,6 +153,14 @@ rules:
   - delete
   - patch
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:
@@ -200,6 +221,17 @@ rules:
   - remoteresources3s
   - remoteresources3s/status
   verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
   - get
   - list
   - patch

--- a/deployer/v2/controllers/marketplace/deployment_controller.go
+++ b/deployer/v2/controllers/marketplace/deployment_controller.go
@@ -134,6 +134,21 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 			}
 		})
 
+	var pDeployment predicate.Funcs = predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_CONTROLLER_DEPLOYMENT_NAME
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_CONTROLLER_DEPLOYMENT_NAME
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_CONTROLLER_DEPLOYMENT_NAME
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
 	pConfigMap := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return e.ObjectNew.GetName() == utils.RHM_OP_CA_BUNDLE_CONFIGMAP
@@ -195,7 +210,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1.Deployment{}, builder.WithPredicates(clusterServiceVersionPredictates)).
+		For(&appsv1.Deployment{}, builder.WithPredicates(pDeployment)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(mapFn),
 			builder.WithPredicates(pConfigMap)).

--- a/deployer/v2/controllers/marketplace/deployment_controller.go
+++ b/deployer/v2/controllers/marketplace/deployment_controller.go
@@ -128,7 +128,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 		func(obj client.Object) []reconcile.Request {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{
-					Name:      utils.RHM_METERING_DEPLOYMENT_NAME,
+					Name:      utils.RHM_CONTROLLER_DEPLOYMENT_NAME,
 					Namespace: obj.GetNamespace(),
 				}},
 			}

--- a/deployer/v2/controllers/marketplace/deployment_controller.go
+++ b/deployer/v2/controllers/marketplace/deployment_controller.go
@@ -1,0 +1,212 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package marketplace
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/manifests"
+	mktypes "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/types"
+	utils "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const ()
+
+// blank assignment to verify that ReconcileOperator implements reconcile.Reconciler
+var _ reconcile.Reconciler = &DeploymentReconciler{}
+
+// OperatorReconciler reconciles objects essential to the deployment
+type DeploymentReconciler struct {
+	// This Client, initialized using mgr.Client() above, is a split Client
+	// that reads objects from the cache and writes to the apiserver
+	Client  client.Client
+	Scheme  *runtime.Scheme
+	Log     logr.Logger
+	factory *manifests.Factory
+}
+
+func (r *DeploymentReconciler) Inject(injector mktypes.Injectable) mktypes.SetupWithManager {
+	injector.SetCustomFields(r)
+	return r
+}
+
+func (r *DeploymentReconciler) InjectFactory(f *manifests.Factory) error {
+	r.factory = f
+	return nil
+}
+
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",namespace=system,resources=configmaps;secrets;services,verbs=get;list;watch;create;patch;update
+// +kubebuilder:rbac:groups="",namespace=system,resources=configmaps;secrets;services,verbs=get;list;watch;create;patch;update
+// +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=servicemonitors,verbs=get;list;watch;create;patch;update
+
+// Enforce the loose operator bundle manifests. OLM applies these once and does not reconcile their state
+// assets/metrics-operator should match the bundle/manifests
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := r.Log.WithValues("Request.Name", request.Name, "Request.Namespace", request.Namespace)
+	reqLogger.Info("Reconciling Deployment")
+
+	instance := &appsv1.Deployment{}
+	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			reqLogger.Error(err, "deployment does not exist")
+			return reconcile.Result{}, nil
+		}
+		reqLogger.Error(err, "Failed to get deployment")
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		cm, err := r.factory.NewRHMOCABundleConfigMap()
+		return cm, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		secret, err := r.factory.NewRHMOServiceMonitorMetricsReaderSecret()
+		return secret, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		svc, err := r.factory.NewRHMOMetricsService()
+		return svc, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		sm, err := r.factory.NewRHMOMetricsServiceMonitor()
+		return sm, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
+
+	// This mapFn will queue deployment/metrics-operator-controller-manager
+	mapFn := handler.MapFunc(
+		func(obj client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name:      utils.RHM_METERING_DEPLOYMENT_NAME,
+					Namespace: obj.GetNamespace(),
+				}},
+			}
+		})
+
+	pConfigMap := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_OP_CA_BUNDLE_CONFIGMAP
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_CA_BUNDLE_CONFIGMAP
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_CA_BUNDLE_CONFIGMAP
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pSecret := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_OP_METRICS_READER_SECRET
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_METRICS_READER_SECRET
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_METRICS_READER_SECRET
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pService := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_OP_METRICS_SERVICE
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_METRICS_SERVICE
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_METRICS_SERVICE
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pServiceMonitor := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_OP_SERVICE_MONITOR
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_SERVICE_MONITOR
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_OP_SERVICE_MONITOR
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}, builder.WithPredicates(clusterServiceVersionPredictates)).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pConfigMap)).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pSecret)).
+		Watches(&source.Kind{Type: &corev1.Service{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pService)).
+		Watches(&source.Kind{Type: &monitoringv1.ServiceMonitor{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pServiceMonitor)).
+		Complete(r)
+}

--- a/deployer/v2/main.go
+++ b/deployer/v2/main.go
@@ -44,6 +44,7 @@ import (
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	opsrcv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"net/http"
@@ -80,6 +81,7 @@ func init() {
 	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(marketplacev1beta1.AddToScheme(scheme))
 	utilruntime.Must(osappsv1.AddToScheme(scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	mktypes.RegisterImageStream(scheme)
 	// +kubebuilder:scaffold:scheme
 }

--- a/deployer/v2/main.go
+++ b/deployer/v2/main.go
@@ -213,6 +213,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.DeploymentReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("DeploymentReconciler"),
+		Scheme: mgr.GetScheme(),
+	}).Inject(injector).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "DeploymentReconciler")
+		os.Exit(1)
+	}
+
 	doneChan := make(chan struct{})
 
 	// +kubebuilder:scaffold:builder

--- a/deployer/v2/main.go
+++ b/deployer/v2/main.go
@@ -115,6 +115,9 @@ func main() {
 			&corev1.Secret{}: {
 				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
 			},
+			&corev1.Service{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
+			},
 			&corev1.ServiceAccount{}: {
 				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
 			},
@@ -134,6 +137,9 @@ func main() {
 				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
 			},
 			&marketplacev1alpha1.RemoteResourceS3{}: {
+				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
+			},
+			&monitoringv1.ServiceMonitor{}: {
 				Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": os.Getenv("POD_NAMESPACE")}),
 			},
 		},

--- a/v2/assets/metrics-operator/metrics-ca-bundle-configmap.yaml
+++ b/v2/assets/metrics-operator/metrics-ca-bundle-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    redhat.marketplace.com/name: metrics-operator
+  name: metrics-operator-serving-certs-ca-bundle

--- a/v2/assets/metrics-operator/metrics-service-monitor.yaml
+++ b/v2/assets/metrics-operator/metrics-service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: metrics-operator
+  name: metrics-operator-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: token
+      name: metrics-operator-servicemonitor-metrics-reader
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      redhat.marketplace.com/name: metrics-operator

--- a/v2/assets/metrics-operator/metrics-service.yaml
+++ b/v2/assets/metrics-operator/metrics-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-operator-controller-manager-metrics-service-tls
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: metrics-operator
+  name: metrics-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: metrics-operator

--- a/v2/assets/metrics-operator/servicemonitor-metrics-reader-secret.yaml
+++ b/v2/assets/metrics-operator/servicemonitor-metrics-reader-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-operator-servicemonitor-metrics-reader
+  labels:
+    name: servicemonitor-metrics-reader
+    redhat.marketplace.com/name: metrics-operator
+  name: metrics-operator-servicemonitor-metrics-reader
+type: kubernetes.io/service-account-token

--- a/v2/assets/redhat-marketplace-operator/metrics-ca-bundle-configmap.yaml
+++ b/v2/assets/redhat-marketplace-operator/metrics-ca-bundle-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    redhat.marketplace.com/name: redhat-marketplace-operator
+  name: redhat-marketplace-serving-certs-ca-bundle

--- a/v2/assets/redhat-marketplace-operator/metrics-service-monitor.yaml
+++ b/v2/assets/redhat-marketplace-operator/metrics-service-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: redhat-marketplace-operator
+  name: redhat-marketplace-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: token
+      name: redhat-marketplace-servicemonitor-metrics-reader
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      redhat.marketplace.com/name: redhat-marketplace-operator

--- a/v2/assets/redhat-marketplace-operator/metrics-service.yaml
+++ b/v2/assets/redhat-marketplace-operator/metrics-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: redhat-marketplace-controller-manager-metrics-service-tls
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: redhat-marketplace-operator
+  name: redhat-marketplace-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+    redhat.marketplace.com/name: redhat-marketplace-operator

--- a/v2/assets/redhat-marketplace-operator/servicemonitor-metrics-reader-secret.yaml
+++ b/v2/assets/redhat-marketplace-operator/servicemonitor-metrics-reader-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: redhat-marketplace-servicemonitor-metrics-reader
+  labels:
+    name: servicemonitor-metrics-reader
+    redhat.marketplace.com/name: redhat-marketplace-operator
+  name: redhat-marketplace-servicemonitor-metrics-reader
+type: kubernetes.io/service-account-token

--- a/v2/config/rbac/role.yaml
+++ b/v2/config/rbac/role.yaml
@@ -178,6 +178,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
@@ -542,6 +555,17 @@ rules:
   - create
   - get
   - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - monitoring.coreos.com

--- a/v2/controllers/marketplace/deployment_controller.go
+++ b/v2/controllers/marketplace/deployment_controller.go
@@ -134,6 +134,21 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 			}
 		})
 
+	var pDeployment predicate.Funcs = predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.RHM_METERING_DEPLOYMENT_NAME
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.RHM_METERING_DEPLOYMENT_NAME
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.RHM_METERING_DEPLOYMENT_NAME
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
 	pConfigMap := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return e.ObjectNew.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
@@ -195,7 +210,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1.Deployment{}, builder.WithPredicates(clusterServiceVersionPredictates)).
+		For(&appsv1.Deployment{}, builder.WithPredicates(pDeployment)).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(mapFn),
 			builder.WithPredicates(pConfigMap)).

--- a/v2/controllers/marketplace/deployment_controller.go
+++ b/v2/controllers/marketplace/deployment_controller.go
@@ -1,0 +1,212 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package marketplace
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/manifests"
+	mktypes "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/types"
+	utils "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const ()
+
+// blank assignment to verify that ReconcileOperator implements reconcile.Reconciler
+var _ reconcile.Reconciler = &DeploymentReconciler{}
+
+// OperatorReconciler reconciles objects essential to the deployment
+type DeploymentReconciler struct {
+	// This Client, initialized using mgr.Client() above, is a split Client
+	// that reads objects from the cache and writes to the apiserver
+	Client  client.Client
+	Scheme  *runtime.Scheme
+	Log     logr.Logger
+	factory *manifests.Factory
+}
+
+func (r *DeploymentReconciler) Inject(injector mktypes.Injectable) mktypes.SetupWithManager {
+	injector.SetCustomFields(r)
+	return r
+}
+
+func (r *DeploymentReconciler) InjectFactory(f *manifests.Factory) error {
+	r.factory = f
+	return nil
+}
+
+// +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",namespace=system,resources=configmaps;secrets;services,verbs=get;list;watch;create;patch;update
+// +kubebuilder:rbac:groups="",namespace=system,resources=configmaps;secrets;services,verbs=get;list;watch;create;patch;update
+// +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=system,resources=servicemonitors,verbs=get;list;watch;create;patch;update
+
+// Enforce the loose operator bundle manifests. OLM applies these once and does not reconcile their state
+// assets/metrics-operator should match the bundle/manifests
+func (r *DeploymentReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := r.Log.WithValues("Request.Name", request.Name, "Request.Namespace", request.Namespace)
+	reqLogger.Info("Reconciling Deployment")
+
+	instance := &appsv1.Deployment{}
+	err := r.Client.Get(context.TODO(), request.NamespacedName, instance)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			reqLogger.Error(err, "deployment does not exist")
+			return reconcile.Result{}, nil
+		}
+		reqLogger.Error(err, "Failed to get deployment")
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		cm, err := r.factory.NewMOCABundleConfigMap()
+		return cm, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		secret, err := r.factory.NewMOServiceMonitorMetricsReaderSecret()
+		return secret, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		svc, err := r.factory.NewMOMetricsService()
+		return svc, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.factory.CreateOrUpdate(r.Client, nil, func() (client.Object, error) {
+		sm, err := r.factory.NewMOMetricsServiceMonitor()
+		return sm, err
+	}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
+
+	// This mapFn will queue deployment/metrics-operator-controller-manager
+	mapFn := handler.MapFunc(
+		func(obj client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name:      utils.RHM_METERING_DEPLOYMENT_NAME,
+					Namespace: obj.GetNamespace(),
+				}},
+			}
+		})
+
+	pConfigMap := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pSecret := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.METRICS_OP_METRICS_READER_SECRET
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_READER_SECRET
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_READER_SECRET
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pService := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.METRICS_OP_METRICS_SERVICE
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	pServiceMonitor := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == utils.METRICS_OP_SERVICE_MONITOR
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_SERVICE_MONITOR
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == utils.METRICS_OP_SERVICE_MONITOR
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}, builder.WithPredicates(clusterServiceVersionPredictates)).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pConfigMap)).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pSecret)).
+		Watches(&source.Kind{Type: &corev1.Service{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pService)).
+		Watches(&source.Kind{Type: &monitoringv1.ServiceMonitor{}},
+			handler.EnqueueRequestsFromMapFunc(mapFn),
+			builder.WithPredicates(pServiceMonitor)).
+		Complete(r)
+}

--- a/v2/main.go
+++ b/v2/main.go
@@ -302,6 +302,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&controllers.DeploymentReconciler{
+		Client: mgr.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("DeploymentReconciler"),
+		Scheme: mgr.GetScheme(),
+	}).Inject(injector).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "DeploymentReconciler")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -97,6 +97,18 @@ const (
 	MeterdefinitionFileServerDeploymentConfig = "catalog-server/deployment-config.yaml"
 	MeterdefinitionFileServerService          = "catalog-server/service.yaml"
 	MeterdefinitionFileServerImageStream      = "catalog-server/image-stream.yaml"
+
+	// metrics-operator olm manifests
+	MOServiceMonitorMetricsReaderSecret = "metrics-operator/servicemonitor-metrics-reader-secret.yaml"
+	MOMetricsServiceMonitor             = "metrics-operator/metrics-service-monitor.yaml"
+	MOMetricsService                    = "metrics-operator/metrics-service.yaml"
+	MOCABundleConfigMap                 = "metrics-operator/metrics-ca-bundle-configmap.yaml"
+
+	// redhat-marketplace-operator olm manifests
+	RHMOServiceMonitorMetricsReaderSecret = "redhat-marketplace-operator/servicemonitor-metrics-reader-secret.yaml"
+	RHMOMetricsServiceMonitor             = "redhat-marketplace-operator/metrics-service-monitor.yaml"
+	RHMOMetricsService                    = "redhat-marketplace-operator/metrics-service.yaml"
+	RHMOCABundleConfigMap                 = "redhat-marketplace-operator/metrics-ca-bundle-configmap.yaml"
 )
 
 var log = logf.Log.WithName("manifests_factory")
@@ -1459,6 +1471,38 @@ func (f *Factory) NewDataServiceTLSSecret(commonNamePrefix string) (*v1.Secret, 
 	s.Data["tls.key"] = serverCertPEM
 
 	return s, nil
+}
+
+func (f *Factory) NewMOServiceMonitorMetricsReaderSecret() (*v1.Secret, error) {
+	return f.NewSecret(MustAssetReader(MOServiceMonitorMetricsReaderSecret))
+}
+
+func (f *Factory) NewMOMetricsServiceMonitor() (*monitoringv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(MustAssetReader(MOMetricsServiceMonitor))
+}
+
+func (f *Factory) NewMOMetricsService() (*corev1.Service, error) {
+	return f.NewService(MustAssetReader(MOMetricsService))
+}
+
+func (f *Factory) NewMOCABundleConfigMap() (*corev1.ConfigMap, error) {
+	return f.NewConfigMap(MustAssetReader(MOCABundleConfigMap))
+}
+
+func (f *Factory) NewRHMOServiceMonitorMetricsReaderSecret() (*v1.Secret, error) {
+	return f.NewSecret(MustAssetReader(RHMOServiceMonitorMetricsReaderSecret))
+}
+
+func (f *Factory) NewRHMOMetricsServiceMonitor() (*monitoringv1.ServiceMonitor, error) {
+	return f.NewServiceMonitor(MustAssetReader(RHMOMetricsServiceMonitor))
+}
+
+func (f *Factory) NewRHMOMetricsService() (*corev1.Service, error) {
+	return f.NewService(MustAssetReader(RHMOMetricsService))
+}
+
+func (f *Factory) NewRHMOCABundleConfigMap() (*corev1.ConfigMap, error) {
+	return f.NewConfigMap(MustAssetReader(RHMOCABundleConfigMap))
 }
 
 func init() {

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -49,6 +49,14 @@ const (
 	METERBASE_PROMETHEUS_SERVICE_NAME      = "rhm-prometheus-meterbase"
 	OPERATOR_CERTS_CA_BUNDLE_NAME          = "serving-certs-ca-bundle"
 	RHM_COS_UPLOADER_SECRET                = "rhm-cos-uploader-secret"
+	METRICS_OP_METRICS_READER_SECRET       = "metrics-operator-servicemonitor-metrics-reader"
+	METRICS_OP_CA_BUNDLE_CONFIGMAP         = "metrics-operator-serving-certs-ca-bundle"
+	METRICS_OP_SERVICE_MONITOR             = "metrics-operator-controller-manager-metrics-monitor"
+	METRICS_OP_METRICS_SERVICE             = "metrics-operator-controller-manager-metrics-service"
+	RHM_OP_METRICS_READER_SECRET           = "redhat-marketplace-operator-servicemonitor-metrics-reader"
+	RHM_OP_CA_BUNDLE_CONFIGMAP             = "redhat-marketplace-operator-serving-certs-ca-bundle"
+	RHM_OP_SERVICE_MONITOR                 = "redhat-marketplace-operator-controller-manager-metrics-monitor"
+	RHM_OP_METRICS_SERVICE                 = "redhat-marketplace-operator-controller-manager-metrics-service"
 
 	/* RHOS Monitoring Resource Names */
 	OPENSHIFT_MONITORING_NAMESPACE                              = "openshift-monitoring"

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -53,10 +53,10 @@ const (
 	METRICS_OP_CA_BUNDLE_CONFIGMAP         = "metrics-operator-serving-certs-ca-bundle"
 	METRICS_OP_SERVICE_MONITOR             = "metrics-operator-controller-manager-metrics-monitor"
 	METRICS_OP_METRICS_SERVICE             = "metrics-operator-controller-manager-metrics-service"
-	RHM_OP_METRICS_READER_SECRET           = "redhat-marketplace-operator-servicemonitor-metrics-reader"
-	RHM_OP_CA_BUNDLE_CONFIGMAP             = "redhat-marketplace-operator-serving-certs-ca-bundle"
-	RHM_OP_SERVICE_MONITOR                 = "redhat-marketplace-operator-controller-manager-metrics-monitor"
-	RHM_OP_METRICS_SERVICE                 = "redhat-marketplace-operator-controller-manager-metrics-service"
+	RHM_OP_METRICS_READER_SECRET           = "redhat-marketplace-servicemonitor-metrics-reader"
+	RHM_OP_CA_BUNDLE_CONFIGMAP             = "redhat-marketplace-serving-certs-ca-bundle"
+	RHM_OP_SERVICE_MONITOR                 = "redhat-marketplace-controller-manager-metrics-monitor"
+	RHM_OP_METRICS_SERVICE                 = "redhat-marketplace-controller-manager-metrics-service"
 
 	/* RHOS Monitoring Resource Names */
 	OPENSHIFT_MONITORING_NAMESPACE                              = "openshift-monitoring"


### PR DESCRIPTION
create controller for each operator that specifically reconciles the loose bundle manifests 

problem: typically OLM will create the 4 bundle loose resources: secret, servicemonitor, service, configmap which enable protected /metrics endpoint. The Deployment specifically relies on the configmap volume to start. The secret can be prematurely destroyed if OLM creates the ServiceAccount before the Secret, as the Secret reconciler will delete an annotated secret if the serviceaccount does not exist (yet). The loose resources are not reconciled by OLM if they are modified/deleted.
