### PR TITLE
retry initial conn

### DIFF
--- a/datareporter/v2/api/v1alpha1/datareporterconfig_types.go
+++ b/datareporter/v2/api/v1alpha1/datareporterconfig_types.go
@@ -76,12 +76,14 @@ func init() {
 const (
 
 	// license not accepted condition, operator will not process events
-	ConditionNoLicense status.ConditionType = "NoLicense"
-
-	// problem with data upload to data service
-	ConditionUploadFailure status.ConditionType = "UploadFailed"
-
+	ConditionNoLicense       status.ConditionType   = "NoLicense"
 	ReasonLicenseNotAccepted status.ConditionReason = "LicenseNotAccepted"
 
-	ReasonUploadFailed status.ConditionReason = "UploadFailed"
+	// problem with data upload to data service
+	ConditionUploadFailure status.ConditionType   = "UploadFailed"
+	ReasonUploadFailed     status.ConditionReason = "UploadFailed"
+
+	// unable to connect to data service
+	ConditionConnectionFailure status.ConditionType   = "DataServiceConnectionFailed"
+	ReasonConnectionFailure    status.ConditionReason = "DataServiceConnectionFailed"
 )

--- a/datareporter/v2/config/manifests/bases/ibm-data-reporter-operator.clusterserviceversion.yaml
+++ b/datareporter/v2/config/manifests/bases/ibm-data-reporter-operator.clusterserviceversion.yaml
@@ -13,11 +13,6 @@ spec:
     - description: DataReporterConfig is the Schema for the datareporterconfigs API
       displayName: Data Reporter Config
       kind: DataReporterConfig
-      name: datareporterconfigs.cache.marketplace.redhat.com
-      version: v1alpha1
-    - description: DataReporterConfig is the Schema for the datareporterconfigs API
-      displayName: Data Reporter Config
-      kind: DataReporterConfig
       name: datareporterconfigs.marketplace.redhat.com
       version: v1alpha1
     required:
@@ -76,10 +71,10 @@ spec:
     the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS
     OF ANY KIND, either express or implied.\nSee the License for the specific language
     governing permissions and\nlimitations under the License.\n"
-  displayName: Data Reporter
+  displayName: IBM Data Reporter Operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MS44IiBoZWlnaHQ9IjE5LjMzIiB2aWV3Qm94PSIwIDAgNTEuOCAxOS4zMyI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiM0MjZhYjM7fTwvc3R5bGU+PC9kZWZzPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTM4Ljc2LDkuMiwzOC4zLDcuODZIMzAuNjFWOS4yWm0uOSwyLjU3LS40Ny0xLjM1SDMwLjYxdjEuMzVabTUuNzEsMTUuMzdoNi43MVYyNS44SDQ1LjM3djEuMzRabTAtMi41Nmg2LjcxVjIzLjIzSDQ1LjM3djEuMzVabTAtMi41N2g0VjIwLjY3aC00VjIyWm00LTMuOWgtNHYxLjM0aDRWMTguMTFabS00LTEuMjJoNFYxNS41NUg0MS43M2wtLjM4LDEuMDhMNDEsMTUuNTVIMzMuM3YxLjM0aDRWMTUuNjZsLjQ0LDEuMjNoNy4xOGwuNDMtMS4yM3YxLjIzWm00LTMuOUg0Mi42MmwtLjQ3LDEuMzRINDkuNFYxM1pNMzMuMywxOS40NWg0VjE4LjExaC00djEuMzRabTAsMi41Nmg0VjIwLjY3aC00VjIyWm0tMi42OSwyLjU3aDYuNzFWMjMuMjNIMzAuNjF2MS4zNVptMCwyLjU2aDYuNzFWMjUuOEgzMC42MXYxLjM0Wk00NC40LDcuODYsNDMuOTMsOS4yaDguMTVWNy44NlpNNDMsMTEuNzdoOVYxMC40Mkg0My41MUw0MywxMS43N1pNMzMuMywxNC4zM2g3LjI1TDQwLjA4LDEzSDMzLjN2MS4zNFptNS4zNSw1LjEySDQ0bC40Ny0xLjM0SDM4LjE4bC40NywxLjM0Wm0uOSwyLjU2aDMuNTlsLjQ3LTEuMzRIMzkuMDhMMzkuNTUsMjJabS45LDIuNTdoMS43OWwuNDctMS4zNUg0MGwuNDcsMS4zNVptLjksMi41Ni40Ni0xLjM0aC0uOTNsLjQ3LDEuMzRabS0yNi44NCwwaDkuODhhNS4xMSw1LjExLDAsMCwwLDMuNDYtMS4zNEgxNC41MXYxLjM0Wk0yNSwyMC42N1YyMmg0LjUxYTUuNDEsNS40MSwwLDAsMC0uMTctMS4zNFpNMTcuMTksMjJoNFYyMC42N2gtNFYyMlpNMjUsMTQuMzNoNC4zNEE1LjQxLDUuNDEsMCwwLDAsMjkuNTEsMTNIMjV2MS4zNFptLTcuODEsMGg0VjEzaC00djEuMzRabTcuMi02LjQ3SDE0LjUxVjkuMkgyNy44NWE1LjEzLDUuMTMsMCwwLDAtMy40Ni0xLjM0Wm00LjQ0LDIuNTZIMTQuNTF2MS4zNUgyOS4zN2E1LjMsNS4zLDAsMCwwLS41NC0xLjM1Wk0xNy4xOSwxNS41NXYxLjM0SDI3LjcxYTUuMzYsNS4zNiwwLDAsMCwxLjEyLTEuMzRabTEwLjUyLDIuNTZIMTcuMTl2MS4zNEgyOC44M2E1LjM2LDUuMzYsMCwwLDAtMS4xMi0xLjM0Wm0tMTMuMiw2LjQ3SDI4LjgzYTUuMyw1LjMsMCwwLDAsLjU0LTEuMzVIMTQuNTF2MS4zNVpNMy43Nyw5LjJoOS40VjcuODZIMy43N1Y5LjJabTAsMi41N2g5LjRWMTAuNDJIMy43N3YxLjM1Wk0xMC40OCwxM2gtNHYxLjM0aDRWMTNabS00LDMuOWg0VjE1LjU1aC00djEuMzRabTAsMi41Nmg0VjE4LjExaC00djEuMzRabTAsMi41Nmg0VjIwLjY3aC00VjIyWk0zLjc3LDI0LjU4aDkuNFYyMy4yM0gzLjc3djEuMzVabTAsMS4yMmg5LjR2MS4zNEgzLjc3VjI1LjhabTUwLjgyLjMyYy4wOSwwLC4xMywwLC4xMy0uMTJ2LS4wN2MwLS4wOCwwLS4xMi0uMTMtLjEySDU0LjR2LjMxWm0tLjE5LjU2aC0uMjZWMjUuNjFoLjQ5QS4zMi4zMiwwLDAsMSw1NSwyNmEuMzIuMzIsMCwwLDEtLjIuMzJsLjI1LjQxaC0uMjlsLS4yLS4zN0g1NC40di4zN1ptLjk0LS40OHYtLjEzYS43OS43OSwwLDAsMC0xLjU3LDB2LjEzYS43OS43OSwwLDAsMCwxLjU3LDBabS0xLjgxLS4wNmExLDEsMCwxLDEsMSwxLjA1LDEsMSwwLDAsMS0xLTEuMDVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMy43NyAtNy44NikiLz48L3N2Zz4=
+    mediatype: image/svg+xml
   install:
     spec:
       deployments: null
@@ -97,10 +92,16 @@ spec:
   - red hat marketplace
   - operators
   links:
-  - name: V2
-    url: https://v2.domain
-  maturity: alpha
+  - name: Visit the marketplace!
+    url: https://marketplace.redhat.com
+  - name: About
+    url: https://marketplace.redhat.com/en-us/about
+  - name: Support
+    url: https://marketplace.redhat.com/en-us/support
+  maintainers:
+  - email: rhmoper@us.ibm.com
+    name: RHM Operator Team
+  maturity: stable
   provider:
     name: Red Hat Marketplace
-    url: https://github.com/redhat-marketplace/redhat-marketplace-operator
   version: 0.0.0

--- a/datareporter/v2/pkg/events/event_reporter.go
+++ b/datareporter/v2/pkg/events/event_reporter.go
@@ -38,22 +38,8 @@ type EventReporter struct {
 func NewEventReporter(
 	log logr.Logger,
 	config *Config,
+	dataService *dataservice.DataService,
 ) (*EventReporter, error) {
-
-	dataServiceConfig, err := provideDataServiceConfig(
-		config.DataServiceCertFile,
-		config.DataServiceTokenFile,
-		config.Namespace,
-		config.OutputDirectory,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	dataService, err := dataservice.NewDataService(dataServiceConfig)
-	if err != nil {
-		return nil, err
-	}
 
 	return &EventReporter{
 		log:         log.WithValues("process", "EventReporter"),

--- a/reporter/v2/pkg/reporter/uploader.go
+++ b/reporter/v2/pkg/reporter/uploader.go
@@ -71,13 +71,11 @@ func ProvideUploaders(
 			}
 
 			// Set Token
-			log.Info("dacdebug", "reporterConfig.DataServiceTokenFile", reporterConfig.DataServiceTokenFile)
 			opts, err := dataservice.ProvideGRPCCallOptions(reporterConfig.DataServiceTokenFile)
 			if err != nil {
 				return uploaders, err
 			}
 			uploader.SetCallOpts(opts...)
-			log.Info("dacdebug", "opts", opts)
 
 			uploaders = append(uploaders, uploader)
 		case *u.COSS3Uploader:


### PR DESCRIPTION
- NewDataService makes an intial grpc connection to the server
  - move the NewDataService into the scope of Start() instead of NewEventReporter
  - set a status on datareporterconfig if the initial connection fails, typically if dataservice is not available yet
    - can scale down deploy/ibm-metrics-operator-controller-manager sts/rhm-data-service to test
  - provideDataService will loop until the connection is established and a DataService can be returned, the timeout/retry is 60 seconds via the underlying context