### PR TITLE
feat: support ocp 4.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Full registration and visibility of usage metrics on [https://marketplace.redhat
 ### Prerequisites
 * User with **Cluster Admin** role
 * OpenShift Container Platform, major version 4 with any available supported minor version
-* It is required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
+* It is required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
   * A minimum retention time of 168h and minimum storage capacity of 40Gi per volume.
 
 ### Resources Required
@@ -48,7 +48,7 @@ Minimum system resources required:
 
 | Prometheus Provider  | Memory (GB) | CPU (cores) | Disk (GB) | Nodes |
 | --------- | ----------- | ----------- | --------- | ----- |
-| **[Openshift User Workload Monitoring](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html)** |          1  |     0.1       | 2x40        |   2    |
+| **[Openshift User Workload Monitoring](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)** |          1  |     0.1       | 2x40        |   2    |
 
 Multiple nodes are required to provide pod scheduling for high availability for Red Hat Marketplace Data Service and Prometheus.
 

--- a/datareporter/v2/Makefile
+++ b/datareporter/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.13
+OPENSHIFT_VERSIONS ?= v4.10-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/datareporter/v2/Makefile
+++ b/datareporter/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.12
+OPENSHIFT_VERSIONS ?= v4.9-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
@@ -43,7 +43,7 @@ spec:
             name: data-service-token-vol
             readOnly: true
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deployer/v2/Makefile
+++ b/deployer/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.13
+OPENSHIFT_VERSIONS ?= v4.10-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/deployer/v2/Makefile
+++ b/deployer/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.12
+OPENSHIFT_VERSIONS ?= v4.9-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/deployer/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/deployer/v2/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deployer/v2/config/manifests/bases/CSV_description.md
+++ b/deployer/v2/config/manifests/bases/CSV_description.md
@@ -21,7 +21,7 @@ Full registration and visibility of usage metrics on [https://marketplace.redhat
 
 #### The IBM Metrics Operator prequisites the following
 
-1. Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
+1. Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
 2. Edit the cluster-monitoring-config ConfigMap object:
 
    ```sh
@@ -94,7 +94,7 @@ Full registration and visibility of usage metrics on [https://marketplace.redhat
     ```
 
 ### Why is a global pull secret required?
-In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html).
+In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
 
 
 ### Cluster permission requirements

--- a/deployer/v2/config/manifests/bases/redhat-marketplace-operator.clusterserviceversion.yaml
+++ b/deployer/v2/config/manifests/bases/redhat-marketplace-operator.clusterserviceversion.yaml
@@ -62,7 +62,7 @@ spec:
     Automatic approval on the Subscription will also install the IBM Metrics Operator
     automatically. If performing an install with Manual approval, install the IBM
     Metrics Operator first.\n\n#### The IBM Metrics Operator prequisites the following\n\n1.
-    Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html)
+    Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)
     as the Prometheus provider.\n2. Edit the cluster-monitoring-config ConfigMap object:\n\n
     \  ```sh\n   $ oc -n openshift-monitoring edit configmap cluster-monitoring-config\n
     \   ```\n\n3. Add enableUserWorkload: true under data/config.yaml:\n  \n    ```sh\n
@@ -100,8 +100,8 @@ spec:
     Why is a global pull secret required?\nIn order to successfully install the Red
     Hat Marketplace products, you will need to make the pull secret available across
     the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret
-    as a [global pull secret](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets).
-    For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html).\n\n\n###
+    as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets).
+    For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).\n\n\n###
     Cluster permission requirements\n\n|API group             |Resources                 |Verbs
     \                            |\n|----------------------|--------------------------|----------------------------------|\n|apiextensions.k8s.io
     \ |customresourcedefinitions |get;list;watch                    |\n|apps                  |deployments

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -20,7 +20,7 @@ DOCKER_BUILD := docker build
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 DOCKERBUILDXCACHE ?=
 
-KUBE_RBAC_PROXY_IMAGE ?= registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+KUBE_RBAC_PROXY_IMAGE ?= registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
 
 clean-bin:
 	rm -rf $(PROJECT_DIR)/bin

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.13
+OPENSHIFT_VERSIONS ?= v4.10-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -1,7 +1,7 @@
 # Current Operator version
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
-OPENSHIFT_VERSIONS ?= v4.9-v4.12
+OPENSHIFT_VERSIONS ?= v4.9-v4.13
 CHANNELS ?= beta,stable
 DEFAULT_CHANNEL ?= stable
 

--- a/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/v2/config/default/manager_auth_proxy_patch.yaml
@@ -30,7 +30,7 @@ spec:
         - "--metrics-addr=127.0.0.1:8080"
         - "--enable-leader-election"
       - name: kube-rbac-proxy
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/v2/config/manager/kustomization.yaml
+++ b/v2/config/manager/kustomization.yaml
@@ -63,5 +63,5 @@ commonAnnotations:
   dqLiteImage: quay.io/rh-marketplace/redhat-marketplace-data-service:2.11.0-beta.1520
   metricStateImage: quay.io/rh-marketplace/redhat-marketplace-metric-state:2.11.0-beta.1520
   operatorImage: quay.io/rh-marketplace/ibm-metrics-operator:2.11.0-beta.1520
-  rbacProxyImage: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+  rbacProxyImage: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
   reporterImage: quay.io/rh-marketplace/redhat-marketplace-reporter:2.11.0-beta.1520

--- a/v2/config/manager/manager.yaml
+++ b/v2/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
             - name: RELATED_IMAGE_DQLITE
               value: redhat-marketplace-data-service:latest
             - name: RELATED_IMAGE_KUBE_RBAC_PROXY
-              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+              value: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
             - name: RELATED_IMAGE_METRIC_STATE
               value: redhat-marketplace-metric-state:latest
             - name: RELATED_IMAGE_REPORTER

--- a/v2/config/manifests/bases/CSV_description.md
+++ b/v2/config/manifests/bases/CSV_description.md
@@ -16,7 +16,7 @@ The Red Hat Marketplace Operator metering and deployment functionalities have be
 Full registration and visibility of usage metrics on [https://marketplace.redhat.com](https://marketplace.redhat.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Prerequisites
-1. Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
+1. Installations are required to [enable monitoring for user-defined projects](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html) as the Prometheus provider.
 2. Edit the cluster-monitoring-config ConfigMap object:
 
    ```sh
@@ -89,7 +89,7 @@ Full registration and visibility of usage metrics on [https://marketplace.redhat
     ```
 
 ### Why is a global pull secret required?
-In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html).
+In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
 
 
 ### SecurityContextConstraints requirements

--- a/v2/config/manifests/bases/ibm-metrics-operator.clusterserviceversion.yaml
+++ b/v2/config/manifests/bases/ibm-metrics-operator.clusterserviceversion.yaml
@@ -76,7 +76,7 @@ spec:
     registration and visibility of usage metrics on [https://marketplace.redhat.com](https://marketplace.redhat.com)
     requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.\n\n###
     Prerequisites\n1. Installations are required to [enable monitoring for user-defined
-    projects](https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html)
+    projects](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)
     as the Prometheus provider.\n2. Edit the cluster-monitoring-config ConfigMap object:\n\n
     \  ```sh\n   $ oc -n openshift-monitoring edit configmap cluster-monitoring-config\n
     \   ```\n\n3. Add enableUserWorkload: true under data/config.yaml:\n  \n    ```sh\n
@@ -113,8 +113,8 @@ spec:
     Why is a global pull secret required?\nIn order to successfully install the Red
     Hat Marketplace products, you will need to make the pull secret available across
     the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret
-    as a [global pull secret](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets).
-    For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/4.12/openshift_images/managing_images/using-image-pull-secrets.html).\n\n\n###
+    as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets).
+    For alternative approachs, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).\n\n\n###
     SecurityContextConstraints requirements\n\nThe Operators and their components
     support running under the OpenShift Container Platform default restricted and
     restricted-v2 security context constraints.\n\n### Installation Namespace and

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -73,7 +73,7 @@ type Resources struct {
 // RelatedImages stores relatedimages for the operator
 type RelatedImages struct {
 	Reporter                    string `env:"RELATED_IMAGE_REPORTER" envDefault:"reporter:latest"`
-	KubeRbacProxy               string `env:"RELATED_IMAGE_KUBE_RBAC_PROXY" envDefault:"registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12"`
+	KubeRbacProxy               string `env:"RELATED_IMAGE_KUBE_RBAC_PROXY" envDefault:"registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13"`
 	MetricState                 string `env:"RELATED_IMAGE_METRIC_STATE" envDefault:"metric-state:latest"`
 	AuthChecker                 string `env:"RELATED_IMAGE_AUTHCHECK" envDefault:"authcheck:latest"`
 	DQLite                      string `env:"RELATED_IMAGE_DQLITE" envDefault:"dqlite:latest"`


### PR DESCRIPTION
- fix links to use _latest_
- publish bundle supporting 4.13
- this does not bring up the modules to the kube 1.26 / ocp 4.13 set