### PR TITLE
fix: npe TargetNamespace

### DIFF
--- a/deployer/v2/controllers/marketplace/razeedeployment_controller.go
+++ b/deployer/v2/controllers/marketplace/razeedeployment_controller.go
@@ -1163,7 +1163,7 @@ func (r *RazeeDeploymentReconciler) removeWatchkeeperDeployment(req *marketplace
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME,
-			Namespace: *req.Spec.TargetNamespace,
+			Namespace: ptr.ToString(req.Spec.TargetNamespace),
 		},
 	}
 	reqLogger.Info("deleting deployment", "name", utils.RHM_WATCHKEEPER_DEPLOYMENT_NAME)


### PR DESCRIPTION
removeWatchkeeperDeployment() could be called before TargetNamespace is set, typically in disconnected mode
ensure no NPE