### PR TITLE
fix: republish to fix bundle

### DIFF
--- a/datareporter/v2/Makefile
+++ b/datareporter/v2/Makefile
@@ -261,4 +261,5 @@ bundle-pin-images:
 # Run certification test
 .PHONY: test-certify
 test-certify: bundle bundle-pin-images
-	cd hack/certify && ./certify.sh
+	./../../hack/certify/catsource.sh && \
+	./../../hack/certify/certify.sh ibm-data-reporter-operator

--- a/v2/version/version.go
+++ b/v2/version/version.go
@@ -14,5 +14,5 @@
 
 package version
 
-const Version = "2.11.0"
-const LastVersion = "2.10.1"
+const Version = "2.11.1"
+const LastVersion = "2.11.0"


### PR DESCRIPTION
- redhat-marketplace-operator was PR'd with wrong cert id, so bundle is broken