### PR TITLE
fix: replace deprecated set-output

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -206,13 +206,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
     - id: build
       name: Build and push images
@@ -351,13 +354,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
     - id: bundle
       name: Build bundle
@@ -379,9 +385,12 @@ jobs:
         make bundle-dev-index-multiarch
         echo "::endgroup::"
 
-        echo "::set-output name=isDev::$IS_DEV"
-        echo "::set-output name=version::$VERSION"
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=tag::$TAG"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
       env:
         IMAGE_TAG: ${{ steps.version.outputs.tag }}
     - uses: actions/upload-artifact@v2
@@ -405,9 +414,12 @@ jobs:
         echo "::group::Make Dev Index"
         make bundle-dev-index-multiarch
         echo "::endgroup::"
-        echo "::set-output name=isDev::$IS_DEV"
-        echo "::set-output name=version::$VERSION"
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=tag::$TAG"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
       env:
         IMAGE_TAG: ${{ steps.version.outputs.tag }}
     - uses: actions/upload-artifact@v2
@@ -431,9 +443,12 @@ jobs:
         echo "::group::Make Dev Index"
         make bundle-dev-index-multiarch
         echo "::endgroup::"
-        echo "::set-output name=isDev::$IS_DEV"
-        echo "::set-output name=version::$VERSION"
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=tag::$TAG"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
       env:
         IMAGE_TAG: ${{ steps.version.outputs.tag }}
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,10 @@ jobs:
       run: |-
         PR=$(curl -H "Accept: application/vnd.github.v3+json" \
              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.issue.number }}" )
-        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
-        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+#        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
+#        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+        echo "prSha=$(echo $PR | jq -r ".head.sha")" >> $GITHUB_OUTPUT
+        echo "prRef=$(echo $PR | jq -r ".head.ref")" >> $GITHUB_OUTPUT
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -93,13 +95,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
       env:
         REF: ${{ steps.pr.outputs.prRef }}
@@ -165,8 +170,10 @@ jobs:
       run: |-
         PR=$(curl -H "Accept: application/vnd.github.v3+json" \
              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.issue.number }}" )
-        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
-        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+#        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
+#        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+        echo "prSha=$(echo $PR | jq -r ".head.sha")" >> $GITHUB_OUTPUT
+        echo "prRef=$(echo $PR | jq -r ".head.ref")" >> $GITHUB_OUTPUT
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -233,13 +240,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
       env:
         REF: ${{ steps.pr.outputs.prRef }}
@@ -314,8 +324,10 @@ jobs:
       run: |-
         PR=$(curl -H "Accept: application/vnd.github.v3+json" \
              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.issue.number }}" )
-        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
-        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+#        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
+#        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+        echo "prSha=$(echo $PR | jq -r ".head.sha")" >> $GITHUB_OUTPUT
+        echo "prRef=$(echo $PR | jq -r ".head.ref")" >> $GITHUB_OUTPUT
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -382,13 +394,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
       env:
         REF: ${{ steps.pr.outputs.prRef }}
@@ -462,8 +477,10 @@ jobs:
       run: |-
         PR=$(curl -H "Accept: application/vnd.github.v3+json" \
              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.issue.number }}" )
-        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
-        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+#        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
+#        echo "::set-output name=prRef::$(echo $PR |jq -r ".head.ref")"
+        echo "prSha=$(echo $PR | jq -r ".head.sha")" >> $GITHUB_OUTPUT
+        echo "prRef=$(echo $PR | jq -r ".head.ref")" >> $GITHUB_OUTPUT
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -530,13 +547,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
       env:
         REF: ${{ steps.pr.outputs.prRef }}

--- a/.github/workflows/release_status.yml
+++ b/.github/workflows/release_status.yml
@@ -39,8 +39,10 @@ jobs:
         OUTPUT='${{ steps.findAllReleasePRs.outputs.data }}'
         EMPTY=$(echo $OUTPUT | jq -cr '.search.edges | length == 0')
         OUTPUT=$(echo $OUTPUT | jq -cr '[.search.edges[].node]' 2> /dev/null) || echo '[]'
-        echo "::set-output name=emptymatrix::$EMPTY"
-        echo "::set-output name=matrix::{\"include\":$OUTPUT}"
+#        echo "::set-output name=emptymatrix::$EMPTY"
+#        echo "::set-output name=matrix::{\"include\":$OUTPUT}"
+        echo "emptymatrix=$EMPTY" >> $GITHUB_OUTPUT
+        echo "matrix={\"include\":$OUTPUT}" >> $GITHUB_OUTPUT
   status:
     name: Check publish status
     needs:
@@ -56,8 +58,10 @@ jobs:
       run: |-
         PR=$(curl -H "Accept: application/vnd.github.v3+json" \
              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${{ matrix.number }}" )
-        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
-        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+#        echo "::set-output name=prSha::$(echo $PR | jq -r ".head.sha")"
+#        echo "::set-output name=prRef::$(echo $PR | jq -r ".head.ref")"
+        echo "prSha=$(echo $PR | jq -r ".head.sha")" >> $GITHUB_OUTPUT
+        echo "prRef=$(echo $PR | jq -r ".head.ref")" >> $GITHUB_OUTPUT
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -124,13 +128,16 @@ jobs:
         fi
 
         echo "Found version $VERSION"
-        echo "::set-output name=version::$VERSION"
+#        echo "::set-output name=version::$VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Found tag $TAG"
         echo "TAG=$TAG" >> $GITHUB_ENV
-        echo "::set-output name=tag::$TAG"
+#        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
         echo "IS_DEV=$IS_DEV" >> $GITHUB_ENV
-        echo "::set-output name=isDev::$IS_DEV"
+#        echo "::set-output name=isDev::$IS_DEV"
+        echo "isDev=$IS_DEV" >> $GITHUB_OUTPUT
         echo "REF=$REF" >> $GITHUB_ENV
       env:
         REF: ${{ steps.pr.outputs.prRef }}
@@ -167,7 +174,8 @@ jobs:
       run: |-
         make pc-tool
         OUTPUT=$(./bin/partner-connect-tool status --username $RH_USER --password $RH_PASSWORD --images https://connect.redhat.com/projects/5e98b6fac77ce6fca8ac859c/images,,$TAG --images https://connect.redhat.com/projects/5e98b6fc32116b90fd024d06/images,,$TAG --images https://connect.redhat.com/projects/5f36ea2f74cc50b8f01a838d/images,,$TAG --images https://connect.redhat.com/projects/5f62b71018e80cdc21edf22f/images,,$TAG --images https://connect.redhat.com/projects/61649f78d3e2f8d3bcfe30d5/images,,$TAG --images https://connect.redhat.com/projects/5f68c9457115dbd1183ccab6/images,,$TAG)
-        echo "::set-output name=imageStatus::$OUTPUT"
+#        echo "::set-output name=imageStatus::$OUTPUT"
+        echo "imageStatus=$OUTPUT" >> $GITHUB_OUTPUT
       env:
         RH_USER: ${{ secrets['REDHAT_IO_USER'] }}
         RH_PASSWORD: ${{ secrets['REDHAT_IO_PASSWORD'] }}

--- a/.github/workflows/scripts/process_pc_status.sh
+++ b/.github/workflows/scripts/process_pc_status.sh
@@ -17,9 +17,12 @@ EOF
   all_passed=$(echo $results | jq -r '[.[] | select(.certification_status != "Passed")] | length == 0' 2> /dev/null)
 fi
 
-echo "::set-output name=all_published::${all_published:-false}"
-echo "::set-output name=all_passed::${all_passed:-false}"
-echo "::set-output name=pushed::${pushed:-false}"
+#echo "::set-output name=all_published::${all_published:-false}"
+#echo "::set-output name=all_passed::${all_passed:-false}"
+#echo "::set-output name=pushed::${pushed:-false}"
+echo "all_published=${all_published:-false}" >> $GITHUB_OUTPUT
+echo "all_passed=${all_passed:-false}" >> $GITHUB_OUTPUT
+echo "name=pushed=${pushed:-false}" >> $GITHUB_OUTPUT
 
 echo "MD_TABLE<<EOF" >> $GITHUB_ENV
 echo "$table" >> $GITHUB_ENV

--- a/deployer/v2/scripts/bundle_csv.sh
+++ b/deployer/v2/scripts/bundle_csv.sh
@@ -47,5 +47,7 @@ FILENAME="rhm-op-bundle-s${STABLE}-b${BETA}-d${DATETIME}"
 cd $ROOT/deploy/olm-catalog/redhat-marketplace-operator || echo "failed to cd"
 zip -r ${ROOT}/bundle/${FILENAME}.zip . -x 'manifests/*' -x 'metadata/*'
 
-echo "::set-output name=filename::${FILENAME}.zip"
-echo "::set-output name=bundlename::${FILENAME}"
+#echo "::set-output name=filename::${FILENAME}.zip"
+#echo "::set-output name=bundlename::${FILENAME}"
+echo "filename=${FILENAME}.zip" >> $GITHUB_OUTPUT
+echo "bundlename=${FILENAME}" >> $GITHUB_OUTPUT

--- a/v2/scripts/bundle_csv.sh
+++ b/v2/scripts/bundle_csv.sh
@@ -47,5 +47,7 @@ FILENAME="rhm-op-bundle-s${STABLE}-b${BETA}-d${DATETIME}"
 cd $ROOT/deploy/olm-catalog/redhat-marketplace-operator || echo "failed to cd"
 zip -r ${ROOT}/bundle/${FILENAME}.zip . -x 'manifests/*' -x 'metadata/*'
 
-echo "::set-output name=filename::${FILENAME}.zip"
-echo "::set-output name=bundlename::${FILENAME}"
+#echo "::set-output name=filename::${FILENAME}.zip"
+#echo "::set-output name=bundlename::${FILENAME}"
+echo "filename=${FILENAME}.zip" >> $GITHUB_OUTPUT
+echo "bundlename=${FILENAME}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- replace deprecated set-output commands for active workflows
  - cue is not updated, haven't used the generator in a long time