### PR TITLE
remove use of deprecated flags from kube-rbac-proxy

### DIFF
--- a/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
@@ -47,7 +47,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=3"
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key

--- a/deployer/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/deployer/v2/config/default/manager_auth_proxy_patch.yaml
@@ -34,7 +34,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=3"
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key

--- a/metering/v2/test/engine_testcase1/pod.yaml
+++ b/metering/v2/test/engine_testcase1/pod.yaml
@@ -122,7 +122,6 @@ spec:
       name: redhat-marketplace-metric-state-token-49mjw
       readOnly: true
   - args:
-    - --logtostderr
     - --secure-listen-address=:9092
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
     - --upstream=http://127.0.0.1:8080/
@@ -159,7 +158,6 @@ spec:
       name: redhat-marketplace-metric-state-token-49mjw
       readOnly: true
   - args:
-    - --logtostderr
     - --secure-listen-address=:9093
     - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
     - --upstream=http://127.0.0.1:8081/

--- a/v2/assets/catalog-server/deployment-config.yaml
+++ b/v2/assets/catalog-server/deployment-config.yaml
@@ -61,7 +61,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       - args:
-            - --logtostderr
             - --secure-listen-address=:8200
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             - --tls-min-version=VersionTLS12

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -102,9 +102,7 @@ spec:
               memory: 20Mi
           terminationMessagePolicy: FallbackToLogsOnError
         - args:
-            - --logtostderr
             - --secure-listen-address=:8004
-            - --insecure-listen-address=:8005
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             - --tls-min-version=VersionTLS12
             - --upstream=http://127.0.0.1:8003/
@@ -143,7 +141,6 @@ spec:
               name: rhm-data-service-mtls
               readOnly: false
         - args:
-            - --logtostderr
             - --secure-listen-address=:8008
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             - --tls-min-version=VersionTLS12

--- a/v2/assets/metric-state/deployment.yaml
+++ b/v2/assets/metric-state/deployment.yaml
@@ -102,7 +102,6 @@ spec:
             runAsNonRoot: true 
           terminationMessagePolicy: FallbackToLogsOnError
         - args:
-            - --logtostderr
             - --secure-listen-address=:9092
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
             - --tls-min-version=VersionTLS12

--- a/v2/assets/prometheus-operator/deployment-v4.6.yaml
+++ b/v2/assets/prometheus-operator/deployment-v4.6.yaml
@@ -86,7 +86,6 @@ spec:
               name: prometheus-operator-tls
               readOnly: false
         - args:
-            - --logtostderr
             - --secure-listen-address=:8443
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
             - --upstream=https://prometheus-operator.{{NAMESPACE}}.svc:8080/

--- a/v2/assets/prometheus/prometheus-v4.6.yaml
+++ b/v2/assets/prometheus/prometheus-v4.6.yaml
@@ -74,7 +74,6 @@ spec:
         - mountPath: /etc/proxy/htpasswd
           name: secret-rhm-prometheus-meterbase-htpasswd
     - args:
-        - --logtostderr
         - --secure-listen-address=:9092
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
         - --upstream=http://127.0.0.1:9090/

--- a/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/v2/config/default/manager_auth_proxy_patch.yaml
@@ -34,7 +34,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
         - "--v=3"
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key


### PR DESCRIPTION
```
oc logs ibm-data-reporter-operator-controller-manager-78b78dc98b-zb5tv -c kube-rbac-proxy
Flag --logtostderr has been deprecated, will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components
```
---
```
oc logs rhm-metric-state-8f7c7f8f5-49d4v -c kube-rbac-proxy-1
==== Deprecation Warning ======================

Insecure listen address will be removed.
Using --insecure-listen-address won't be possible!

The ability to run kube-rbac-proxy without TLS certificates will be removed.
Not using --tls-cert-file and --tls-private-key-file won't be possible!

For more information, please go to https://github.com/brancz/kube-rbac-proxy/issues/187

===============================================
```
