### PR TITLE
set gomemlimit, update mem limit, update razee images

### DIFF
--- a/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/datareporter/v2/config/default/manager_auth_proxy_patch.yaml
@@ -76,10 +76,16 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 25Mi
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 20Mi
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: kube-rbac-proxy
+              resource: limits.memory
       volumes:
         - name: ibm-data-reporter-operator-metrics-service-tls
           secret:

--- a/deployer/v2/Makefile
+++ b/deployer/v2/Makefile
@@ -37,8 +37,8 @@ DEV_INDEX_IMG ?= $(IMAGE_REGISTRY)/$(DEV_INDEX_NAME)
 OPM_BASE_NAME ?= opm-base
 OPM_BASE_IMG ?= $(IMAGE_REGISTRY)/$(OPM_BASE_NAME)
 
-RRS3_IMAGE ?= us.icr.io/armada-master/remoteresource:2.1.6_eee1907
-WATCHKEEPER_IMAGE ?= us.icr.io/armada-master/watch-keeper:0.8.6_ca20177 
+RRS3_IMAGE ?= us.icr.io/armada-master/remoteresource:2.1.18_5bbfd59
+WATCHKEEPER_IMAGE ?= us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59
 
 namespace ?= redhat-marketplace
 

--- a/deployer/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/deployer/v2/config/default/manager_auth_proxy_patch.yaml
@@ -62,10 +62,16 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 25Mi
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 20Mi
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: kube-rbac-proxy
+              resource: limits.memory
       volumes:
         - name: redhat-marketplace-controller-manager-metrics-service-tls
           secret:

--- a/deployer/v2/config/manager/manager.yaml
+++ b/deployer/v2/config/manager/manager.yaml
@@ -68,9 +68,9 @@ spec:
             - name: RELATED_IMAGE_AUTHCHECK
               value: redhat-marketplace-authcheck:latest
             - name: RELATED_IMAGE_RHM_RRS3_DEPLOYMENT
-              value: us.icr.io/armada-master/remoteresource:2.1.6_eee1907
+              value: us.icr.io/armada-master/remoteresource:2.1.18_5bbfd59
             - name: RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT
-              value: us.icr.io/armada-master/watch-keeper:0.8.6_ca20177
+              value: us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/v2/assets/catalog-server/deployment-config.yaml
+++ b/v2/assets/catalog-server/deployment-config.yaml
@@ -37,7 +37,13 @@ spec:
               memory: 12Mi
             limits:
               cpu: 15m
-              memory: 20Mi
+              memory: 24Mi
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: authcheck
+              resource: limits.memory
           terminationMessagePolicy: FallbackToLogsOnError
       - name: rhm-meterdefinition-file-server
         image: rhm-meterdefinition-file-server-image
@@ -76,9 +82,18 @@ spec:
           - containerPort: 8200
             name: https
         resources:
+          limits:
+            cpu: 20m
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 20Mi
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: kube-rbac-proxy
+              resource: limits.memory
         securityContext: 
           runAsNonRoot: true
         terminationMessagePolicy: FallbackToLogsOnError

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -99,7 +99,13 @@ spec:
               memory: 12Mi
             limits:
               cpu: 15m
-              memory: 20Mi
+              memory: 24Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           terminationMessagePolicy: FallbackToLogsOnError
         - args:
             - --secure-listen-address=:8004
@@ -118,9 +124,18 @@ spec:
             - containerPort: 8004
               name: grpc
           resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
             requests:
               cpu: 10m
               memory: 20Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: kube-rbac-proxy-1
+                resource: limits.memory
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -156,9 +171,18 @@ spec:
             - containerPort: 8008
               name: grpc
           resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
             requests:
               cpu: 10m
               memory: 20Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: kube-rbac-proxy-2
+                resource: limits.memory
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/assets/metric-state/deployment.yaml
+++ b/v2/assets/metric-state/deployment.yaml
@@ -81,17 +81,24 @@ spec:
         - image: redhat-marketplace-authcheck:latest
           name: authcheck
           env:
-          - name: GOGC
-            value: 50
-          - name: PPROF_DEBUG
-            value: "true"
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           resources:
             requests:
               cpu: 10m
               memory: 12Mi
             limits:
               cpu: 15m
-              memory: 20Mi
+              memory: 24Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -116,12 +123,18 @@ spec:
             - containerPort: 9092
               name: https
           resources:
+            limits:
+              cpu: 20m
+              memory: 32Mi
             requests:
               cpu: 10m
               memory: 20Mi
-            limits:
-              cpu: 20m
-              memory: 30Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: kube-rbac-proxy-1
+                resource: limits.memory
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/assets/razee/remote-resource-s3.yaml
+++ b/v2/assets/razee/remote-resource-s3.yaml
@@ -37,7 +37,7 @@ spec:
           resources:
             limits:
               cpu: 20m
-              memory: 20Mi
+              memory: 24Mi
             requests:
               cpu: 10m
               memory: 12Mi

--- a/v2/assets/razee/rr-controller-deployment.yaml
+++ b/v2/assets/razee/rr-controller-deployment.yaml
@@ -31,16 +31,21 @@ spec:
         runAsNonRoot: true
       containers:
         - env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -62,10 +67,16 @@ spec:
           resources:
             limits:
               cpu: 20m
-              memory: 20Mi
+              memory: 24Mi
             requests:
               cpu: 10m
               memory: 12Mi
+          env:
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/assets/razee/watch-keeper-deployment.yaml
+++ b/v2/assets/razee/watch-keeper-deployment.yaml
@@ -31,16 +31,21 @@ spec:
         runAsNonRoot: true    
       containers:
         - env:
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: GOMEMLIMIT
+            valueFrom:
+              resourceFieldRef:
+                containerName: authcheck
+                resource: limits.memory
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -64,7 +69,7 @@ spec:
               memory: 12Mi
             limits:
               cpu: 15m
-              memory: 20Mi
+              memory: 24Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/v2/assets/razee/watch-keeper.yaml
+++ b/v2/assets/razee/watch-keeper.yaml
@@ -50,7 +50,7 @@ spec:
                 key: RAZEEDASH_ORG_KEY
           - name: NODE_ENV
             value: "production"
-        image: "us.icr.io/armada-master/watch-keeper:0.8.3_83f4e3a"
+        image: "us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59"
         imagePullPolicy: Always
         name: watch-keeper
         resources:

--- a/v2/config/default/manager_auth_proxy_patch.yaml
+++ b/v2/config/default/manager_auth_proxy_patch.yaml
@@ -62,10 +62,16 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 25Mi
+            memory: 32Mi
           requests:
             cpu: 10m
             memory: 20Mi
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: kube-rbac-proxy
+              resource: limits.memory
       volumes:
         - name: ibm-metrics-operator-controller-manager-metrics-service-tls
           secret:

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -84,8 +84,8 @@ type RelatedImages struct {
 	ConfigMapReloader           string `env:"RELATED_IMAGE_CONFIGMAP_RELOADER" envDefault:"registry.redhat.io/openshift4/ose-configmap-reloader:v4.11"`
 	PrometheusConfigMapReloader string `env:"RELATED_IMAGE_PROMETHEUS_CONFIGMAP_RELOADER" envDefault:"registry.redhat.io/openshift4/ose-prometheus-config-reloader:v4.11"`
 	OAuthProxy                  string `env:"RELATED_IMAGE_OAUTH_PROXY" envDefault:"registry.redhat.io/openshift4/ose-oauth-proxy:v4.11"`
-	RemoteResource              string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.6_eee1907"`
-	WatchKeeper                 string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.6_ca20177"`
+	RemoteResource              string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.18_5bbfd59"`
+	WatchKeeper                 string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59"`
 	MeterDefFileServer          string `env:"RELATED_IMAGE_METERDEF_FILE_SERVER" envDefault:"quay.io/rh-marketplace/rhm-meterdefinition-file-server:v1"`
 }
 
@@ -101,8 +101,8 @@ type OSRelatedImages struct {
 	ConfigMapReloader           string `env:"OS_IMAGE_CONFIGMAP_RELOADER" envDefault:"quay.io/coreos/configmap-reload:v0.0.1"`
 	PrometheusConfigMapReloader string `env:"OS_IMAGE_PROMETHEUS_CONFIGMAP_RELOADER" envDefault:"quay.io/coreos/prometheus-config-reloader:v0.42.1"`
 	OAuthProxy                  string `env:"OS_IMAGE_OAUTH_PROXY" envDefault:"quay.io/oauth2-proxy/oauth2-proxy:v6.1.1"`
-	RemoteResource              string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.6_eee1907"`
-	WatchKeeper                 string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.6_ca20177"`
+	RemoteResource              string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.18_5bbfd59"`
+	WatchKeeper                 string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59"`
 	MeterDefFileServer          string `env:"RELATED_IMAGE_METERDEF_FILE_SERVER" envDefault:"quay.io/rh-marketplace/rhm-meterdefinition-file-server:v1"`
 }
 

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -85,8 +85,8 @@ const (
 
 	/* Razee Controller Values */
 	RAZEE_DEPLOYMENT_FINALIZER                = "razeedeploy.finalizer.marketplace.redhat.com"
-	DEFAULT_RHM_RRS3_DEPLOYMENT_IMAGE         = "us.icr.io/armada-master/remoteresource:2.1.6_eee1907"
-	DEFAULT_RHM_WATCH_KEEPER_DEPLOYMENT_IMAGE = "us.icr.io/armada-master/watch-keeper:0.8.6_ca20177 "
+	DEFAULT_RHM_RRS3_DEPLOYMENT_IMAGE         = "us.icr.io/armada-master/remoteresource:2.1.18_5bbfd59"
+	DEFAULT_RHM_WATCH_KEEPER_DEPLOYMENT_IMAGE = "us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59"
 	IBM_COS_READER_KEY_FIELD                  = "IBM_COS_READER_KEY"
 	BUCKET_NAME_FIELD                         = "BUCKET_NAME"
 	IBM_COS_URL_FIELD                         = "IBM_COS_URL"


### PR DESCRIPTION
- Set GOMEMLIMIT env to make go garbage collection aware of the container limit, and prevent OOMKilled
- Set authcheck to 24Mi as needed by fips-detect during startup
- Set kube-rbac-proxy limit to 32Mi, in testing it seemed necessary to prevent OOMKilled from a traffic burst
- Update the razee images, now that the multi-arch is fixed on the manifest
```
skopeo inspect  --raw docker://us.icr.io/armada-master/watch-keeper:0.8.9_5bbfd59
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1728,
         "digest": "sha256:c1ac9fcab98dcdf39c9be878386c0e3bc01dea90ad125c67d7f3db0ef9170ca9",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2204,
         "digest": "sha256:d469fe81d6ca585e20bebcbcccfd1395ce84c714617cbf3d7b325bc3030b7e7a",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 2204,
         "digest": "sha256:3a4f6f48fcf86562112098969d9c7268fcde3efe65ab5ab114b43c02a8959bfb",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```