### PR TITLE
pin base go-toolset, use ds go-toolset as builder

### DIFF
--- a/authchecker/v2/Dockerfile
+++ b/authchecker/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset AS dqlite-lib-builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10 AS dqlite-lib-builder
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS
@@ -15,7 +15,8 @@ USER 0
 # libuv-devel is only available from CRB with subscription, build it ourselves
 # raft, dqlite not available on UBI or EPEL, build it ourselves
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+RUN dnf update -y && \
+    dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     dnf install -y libsqlite3x-devel libtool pkgconf-pkg-config lz4 lz4-devel && \
     dnf remove epel-release-latest-8 && \
     dnf clean all  && \

--- a/datareporter/v2/Dockerfile
+++ b/datareporter/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 

--- a/deployer/v2/Dockerfile
+++ b/deployer/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 

--- a/metering/v2/Dockerfile
+++ b/metering/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 

--- a/reporter/v2/Dockerfile
+++ b/reporter/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,6 +1,6 @@
 ARG REGISTRY=quay.io/rh-marketplace
 
-FROM registry.access.redhat.com/ubi8/go-toolset AS builder
+FROM ${REGISTRY}/data-service-base:ubi8 AS builder
 ARG path
 ARG ARCHS
 


### PR DESCRIPTION
- pin the go-toolset version and add a pkg update step
  - rh has broken the `latest` on ppc64le by somehow deleting `/etc/yum.repos.d/ubi.repo` only on this arch
- use the dataservice base as the go-toolset base for all images, as it is expected to be a better known good, if rh is going to be breaking their `latest`