### PR TITLE
Bugfix/probe

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -51,7 +51,8 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
+COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect
+COPY --from=builder /opt/app-root/src/go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.10-10
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
- revert to using go-toolset:1.19, it appears the ppc64le image is fixed
- restore grpc-health-probe in the data-service image to fix liveness probe