### PR TITLE
static kube-rbac-proxy tag

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -231,7 +231,10 @@ func ProvideInfrastructureAwareConfig(
 				cfg.RelatedImages.OAuthProxy = "registry.redhat.io/openshift4/ose-oauth-proxy:v" + ocpTag
 				cfg.RelatedImages.ConfigMapReloader = "registry.redhat.io/openshift4/ose-configmap-reloader:v" + ocpTag
 				cfg.RelatedImages.PrometheusConfigMapReloader = "registry.redhat.io/openshift4/ose-prometheus-config-reloader:v" + ocpTag
-				cfg.RelatedImages.KubeRbacProxy = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v" + ocpTag
+
+				//v4.11 has transport error with data-service, use a static tag for now
+				//cfg.RelatedImages.KubeRbacProxy = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v" + ocpTag
+				cfg.RelatedImages.KubeRbacProxy = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13"
 			} else {
 				log.Info("couldn't determind version, using default images")
 			}


### PR DESCRIPTION
`ose-kube-rbac-proxy:v4.11` is producing this error when interacting with data-service
I am not certain what change started causing this behavior, whether the required TLS configuration change, or a grpc update in data-service.
`ose-kube-rbac-proxy:v4.11`  is on a much older branch of the rbac-proxy
`v4.12` & `v4.13` communicate correctly
We will set the `ose-kube-rbac-proxy` statically until `v4.11` is out of service

```
2023/09/21 17:24:57 http: proxy error: net/http: HTTP/1.x transport connection broken: malformed HTTP response "\x00\x00\x06\x04\x00\x00\x00\x00\x00\x00\x05\x00\x00@\x00"
2023/09/21 17:25:02 http: proxy error: write tcp 127.0.0.1:42928->127.0.0.1:8003: write: connection reset by peer
```