### PR TITLE
Bugfix/autobuild

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: "--max_old_space_size=6000"
       ARCHS: "amd64"
     strategy:
       fail-fast: false

--- a/deployer/v2/controllers/marketplace/razeedeployment_controller_test.go
+++ b/deployer/v2/controllers/marketplace/razeedeployment_controller_test.go
@@ -229,6 +229,7 @@ var _ = Describe("Testing with Ginkgo", func() {
 				!utils.Contains(secretNames, utils.COS_READER_KEY_NAME)
 		}, timeout, interval).Should(BeTrue())
 
+		// Catalogs are reconciled regardless of secret
 		Eventually(func() bool {
 			catalogSourceList := &operatorsv1alpha1.CatalogSourceList{}
 			k8sClient.List(context.TODO(), catalogSourceList)
@@ -240,8 +241,8 @@ var _ = Describe("Testing with Ginkgo", func() {
 
 			utils.PrettyPrint(catalogSourceNames)
 
-			return !utils.Contains(catalogSourceNames, utils.IBM_CATALOGSRC_NAME) &&
-				!utils.Contains(catalogSourceNames, utils.OPENCLOUD_CATALOGSRC_NAME)
+			return utils.Contains(catalogSourceNames, utils.IBM_CATALOGSRC_NAME) &&
+				utils.Contains(catalogSourceNames, utils.OPENCLOUD_CATALOGSRC_NAME)
 		}, timeout, interval).Should(BeTrue())
 	})
 


### PR DESCRIPTION
- don't override node runtime memory
- fix incorrect/race in `no secret` test, catalogs get created if there is valid RazeeDeployment. Test was racing for false completion result before reconciler could create catalogs.