### PR TITLE
fix: remove unused vars

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop, bugfix/*, feature/*, hotfix/*, master, release/* ]
+    branches: [ develop, master, release/* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ develop ]
+    branches: [ develop, master ]
   schedule:
     - cron: '23 4 * * 1'
 

--- a/v2/pkg/prometheus/promcfg.go
+++ b/v2/pkg/prometheus/promcfg.go
@@ -84,33 +84,6 @@ func (cg *configGenerator) GenerateConfig(
 		return nil, errors.Wrap(err, "parse version")
 	}
 
-	scrapeInterval := v1.Duration("30s")
-	if p.Spec.ScrapeInterval != "" {
-		scrapeInterval = p.Spec.ScrapeInterval
-	}
-
-	evaluationInterval := v1.Duration("30s")
-	if p.Spec.EvaluationInterval != "" {
-		evaluationInterval = p.Spec.EvaluationInterval
-	}
-
-	globalItems := yaml.MapSlice{
-		{Key: "evaluation_interval", Value: evaluationInterval},
-		{Key: "scrape_interval", Value: scrapeInterval},
-		{Key: "external_labels", Value: buildExternalLabels(p)},
-	}
-
-	if version.GTE(semver.MustParse("2.16.0")) && p.Spec.QueryLogFile != "" {
-		globalItems = append(globalItems, yaml.MapItem{
-			Key: "query_log_file", Value: p.Spec.QueryLogFile,
-		})
-	}
-
-	ruleFilePaths := []string{}
-	for _, name := range ruleConfigMapNames {
-		ruleFilePaths = append(ruleFilePaths, rulesDir+"/"+name+"/*.yaml")
-	}
-
 	sMonIdentifiers := make([]string, len(sMons))
 	i := 0
 	for k := range sMons {


### PR DESCRIPTION
For: https://github.com/redhat-marketplace/redhat-marketplace-operator/security/code-scanning/65

prior change started to unravel that none of these vars are used

prometheus pkg needs to be cleaned up overall, as half the funcs are for the removed prometheus setup, where we now use User Workload Monitoring - we just use the API funcs. That will be a separate story overall.

- remove codeql scanning for `bugfix/*, feature/*, hotfix/*` branches. This results in duplicate scan tasks for PRs, and is only useful for `release/*` branch validation.