### PR TITLE
Fix the namespace name to redhat-marketplace

### DIFF
--- a/datareporter/v2/README.md
+++ b/datareporter/v2/README.md
@@ -57,13 +57,13 @@ spec:
       bmeta1: bmetadata1
       cmeta1: cmetadata1
       dmeta1: dmetadata1
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api
 ```
 
 ### User Configuration
 
 - The ClusterRole for api access is `clusterrole/ibm-data-reporter-operator-api`
-- The default ServiceAccount provided as an api user is `system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api`
+- The default ServiceAccount provided as an api user is `system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api`
   - The default ClusterRoleBinding for this user is `clusterrolebinding/ibm-data-reporter-operator-api`
 
 Optional:

--- a/datareporter/v2/config/manifests/bases/ibm-data-reporter-operator.clusterserviceversion.yaml
+++ b/datareporter/v2/config/manifests/bases/ibm-data-reporter-operator.clusterserviceversion.yaml
@@ -62,9 +62,9 @@ spec:
     with the additional metadata\n\n```YAML\napiVersion: marketplace.redhat.com/v1alpha1\nkind:
     DataReporterConfig\nmetadata:\n  name: datareporterconfig\nspec:\n  userConfig:\n
     \ - metadata:\n      ameta1: ametadata1\n      bmeta1: bmetadata1\n      cmeta1:
-    cmetadata1\n      dmeta1: dmetadata1\n    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api\n```\n\n###
+    cmetadata1\n      dmeta1: dmetadata1\n    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api\n```\n\n###
     User Configuration\n\n- The ClusterRole for api access is `clusterrole/ibm-data-reporter-operator-api`\n-
-    The default ServiceAccount provided as an api user is `system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api`\n
+    The default ServiceAccount provided as an api user is `system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api`\n
     \ - The default ClusterRoleBinding for this user is `clusterrolebinding/ibm-data-reporter-operator-api`\n\nOptional:\n\n-
     To create an additional ServiceAccount and ClusterRoleBinding for api access\n\n```SHELL\nNAMESPACE=$(oc
     config view --minify -o jsonpath='{..namespace}') && \\\noc create serviceaccount

--- a/datareporter/v2/config/samples/marketplace_v1alpha1_datareporterconfig.yaml
+++ b/datareporter/v2/config/samples/marketplace_v1alpha1_datareporterconfig.yaml
@@ -15,4 +15,4 @@ spec:
       bmeta1: bmetadata1
       cmeta1: cmetadata1
       dmeta1: dmetadata1
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api

--- a/datareporter/v2/hack/test/datareporterconfig.yaml
+++ b/datareporter/v2/hack/test/datareporterconfig.yaml
@@ -15,28 +15,28 @@ spec:
       bmeta1: bmetadata1
       cmeta1: cmetadata1
       dmeta1: dmetadata1
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api-1
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api-1
   - metadata:
       ameta1: ametadata2
       bmeta1: bmetadata2
       cmeta1: cmetadata2
       dmeta1: dmetadata2
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api-2
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api-2
   - metadata:
       ameta1: ametadata3
       bmeta1: bmetadata3
       cmeta1: cmetadata3
       dmeta1: dmetadata3
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api-3
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api-3
   - metadata:
       ameta1: ametadata4
       bmeta1: bmetadata4
       cmeta1: cmetadata4
       dmeta1: dmetadata4
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api-4
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api-4
   - metadata:
       ameta1: ametadata5
       bmeta1: bmetadata5
       cmeta1: cmetadata5
       dmeta1: dmetadata5
-    userName: system:serviceaccount:openshift-redhat-marketplace:ibm-data-reporter-operator-api-5
+    userName: system:serviceaccount:redhat-marketplace:ibm-data-reporter-operator-api-5


### PR DESCRIPTION
The namespace `openshift-redhat-marketplace` is no longer used - using `redhat-marketplace` namespace name instead.