### PR TITLE
Update infra MeterDef, fix KubeRbacProxy tag bug

### DIFF
--- a/v2/assets/metric-state/meterdefinition.yaml
+++ b/v2/assets/metric-state/meterdefinition.yaml
@@ -9,7 +9,7 @@ spec:
     - aggregation: avg
       metricId: rhm-metric-state-uptime
       name: rhm-metric-state-uptime
-      period: 1h
+      period: 24h
       query: avg_over_time(up{job="rhm-metric-state-service"}[5m])
       workloadType: Pod
       metricType: infrastructure

--- a/v2/assets/prometheus/user-workload-monitoring-meterdefinition.yaml
+++ b/v2/assets/prometheus/user-workload-monitoring-meterdefinition.yaml
@@ -10,7 +10,7 @@ spec:
     - aggregation: avg
       metricId: prometheus-user-workload-uptime
       name: prometheus-user-workload-uptime
-      period: 1h
+      period: 24h
       query: avg_over_time(up{job="prometheus-user-workload"}[5m])
       workloadType: Pod
       metricType: infrastructure

--- a/v2/assets/reporter/meterdefinition.yaml
+++ b/v2/assets/reporter/meterdefinition.yaml
@@ -9,7 +9,7 @@ spec:
     - aggregation: sum
       metricId: rhm-meter-report-job-failed
       name: rhm-meter-report-job-failed
-      period: 1h
+      period: 24h
       query: 'sum(kube_job_failed{job_name=~"rhm-meter-report-upload-.*"}) without (condition)'
       workloadType: Service
       metricType: infrastructure

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -231,10 +231,6 @@ func ProvideInfrastructureAwareConfig(
 				cfg.RelatedImages.OAuthProxy = "registry.redhat.io/openshift4/ose-oauth-proxy:v" + ocpTag
 				cfg.RelatedImages.ConfigMapReloader = "registry.redhat.io/openshift4/ose-configmap-reloader:v" + ocpTag
 				cfg.RelatedImages.PrometheusConfigMapReloader = "registry.redhat.io/openshift4/ose-prometheus-config-reloader:v" + ocpTag
-
-				//v4.11 has transport error with data-service, use a static tag for now
-				//cfg.RelatedImages.KubeRbacProxy = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v" + ocpTag
-				cfg.RelatedImages.KubeRbacProxy = "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14"
 			} else {
 				log.Info("couldn't determind version, using default images")
 			}


### PR DESCRIPTION
- Change infrastructure MeterDefinitions to a 24h time period for reporting, to reduce frequent data points (requested by Mari)
- Remove KubeRbacProxy override to tagged versioned image, always use the image resolved from the utils.Makefile, with sha256 (reported bug)