### PR TITLE
feat: dro manifestType override

### DIFF
--- a/datareporter/v2/main.go
+++ b/datareporter/v2/main.go
@@ -203,7 +203,7 @@ func main() {
 
 	rc := retryablehttp.NewClient()
 	sc := rc.StandardClient() // *http.Client
-	dataFilters := datafilter.NewDataFilters(ctrl.Log.WithName("datafilter"), mgr.GetClient(), sc)
+	dataFilters := datafilter.NewDataFilters(ctrl.Log.WithName("datafilter"), mgr.GetClient(), sc, eventEngine, config)
 
 	if err = (&controllers.DataReporterConfigReconciler{
 		Client:      mgr.GetClient(),

--- a/datareporter/v2/pkg/datafilter/datafilter_suite_test.go
+++ b/datareporter/v2/pkg/datafilter/datafilter_suite_test.go
@@ -68,7 +68,11 @@ var _ = BeforeSuite(func() {
 
 	rc := retryablehttp.NewClient()
 	sc := rc.StandardClient()
-	dataFilters = datafilter.NewDataFilters(ctrl.Log.WithName("datafilter"), k8sClient, sc)
+
+	// Test DataFilter Build func
+	// Does not need EventEngine pointers
+	// FilterAndUpload test via server suite
+	dataFilters = datafilter.NewDataFilters(ctrl.Log.WithName("datafilter"), k8sClient, sc, nil, nil)
 
 	// k8s Configuration Objects
 

--- a/datareporter/v2/pkg/events/event_reporter.go
+++ b/datareporter/v2/pkg/events/event_reporter.go
@@ -49,7 +49,7 @@ func NewEventReporter(
 	}, nil
 }
 
-func (r *EventReporter) Report(metadata Metadata, eventJsons EventJsons) error {
+func (r *EventReporter) Report(metadata Metadata, manifestType string, eventJsons EventJsons) error {
 
 	dir, err := os.MkdirTemp(r.config.OutputDirectory, "datareporter-")
 	if err != nil {
@@ -57,7 +57,7 @@ func (r *EventReporter) Report(metadata Metadata, eventJsons EventJsons) error {
 	}
 	defer os.RemoveAll(dir)
 
-	archiveFilePath, err := r.writeReport(dir, metadata, eventJsons)
+	archiveFilePath, err := r.writeReport(dir, metadata, manifestType, eventJsons)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (r *EventReporter) Report(metadata Metadata, eventJsons EventJsons) error {
 }
 
 // write the report to disk and return archivePath
-func (r *EventReporter) writeReport(dir string, metadata Metadata, eventJsons EventJsons) (string, error) {
+func (r *EventReporter) writeReport(dir string, metadata Metadata, manifestType string, eventJsons EventJsons) (string, error) {
 
 	// subdir for json files
 	filesDir := filepath.Join(dir, "archive")
@@ -80,7 +80,7 @@ func (r *EventReporter) writeReport(dir string, metadata Metadata, eventJsons Ev
 	}
 
 	// Generate and write manifest
-	manifest := Manifest{Type: "dataReporter", Version: "1"}
+	manifest := Manifest{Type: manifestType, Version: "1"}
 
 	manifestBytes, err := json.Marshal(manifest)
 	if err != nil {

--- a/datareporter/v2/pkg/events/event_type.go
+++ b/datareporter/v2/pkg/events/event_type.go
@@ -82,6 +82,12 @@ func (a *UserConfigs) GetMetadata(userName string) Metadata {
 type Event struct {
 	User string // x-remote-user the Event was posted by
 	json.RawMessage
+	ManifestType string // dataReporter or override
+}
+
+type UserManifestType struct {
+	User         string
+	ManifestType string
 }
 
 type Events []Event


### PR DESCRIPTION
Move the send to the eventChan from the handler to DataFilters, as a match may override its manifestType
Provide eventEngine & Config pointers to DataFilters
Change the accumulator map key from user to {user, manifestType}
Default path should function the same, TBD to test a filtered path