### PR TITLE
feat: datafilter fixes and tests

### DIFF
--- a/datareporter/v2/pkg/datafilter/datafilter_test.go
+++ b/datareporter/v2/pkg/datafilter/datafilter_test.go
@@ -54,7 +54,7 @@ var _ = Describe("DataFilter", func() {
 							MatchExpressions: []string{
 								`$.properties.productId`,
 								`$[?($.properties.source != null)]`,
-								`$[?($.properties.unit == "AppPoints")]`,
+								`$[?($.properties.unit == "Points")]`,
 								`$[?($.properties.quantity >= 0)]`,
 								`$[?($.timestamp != null)]`,
 							},
@@ -270,23 +270,22 @@ var _ = Describe("DataFilter", func() {
 			})
 
 			// TODO: implement payload
-			/*
-				It("should error on Authorization Data Secret Name not found", func() {
-					drcBadAuthDataSecretName := drc
-					drcBadAuthDataSecretName.Spec.DataFilters[0].AltDestinations[0].Authorization.DataSecret.Name = "auth-data-secret-name-not-here"
 
-					err := dataFilters.Build(&drcBadAuthDataSecretName)
-					Expect(err).To(HaveOccurred())
-				})
+			It("should error on Authorization Body Data Secret Name not found", func() {
+				drcBadAuthDataSecretName := drc
+				drcBadAuthDataSecretName.Spec.DataFilters[0].AltDestinations[0].Authorization.BodyData.SecretKeyRef.Name = "auth-data-secret-name-not-here"
 
-				It("should error on Authorization Data Secret Key not found", func() {
-					drcBadAuthDataSecretKey := drc
-					drcBadAuthDataSecretKey.Spec.DataFilters[0].AltDestinations[0].Authorization.DataSecret.Key = "auth-data-secret-key-not-here"
+				err := dataFilters.Build(&drcBadAuthDataSecretName)
+				Expect(err).To(HaveOccurred())
+			})
 
-					err := dataFilters.Build(&drcBadAuthDataSecretKey)
-					Expect(err).To(HaveOccurred())
-				})
-			*/
+			It("should error on Authorization Body Data Secret Key not found", func() {
+				drcBadAuthDataSecretKey := drc
+				drcBadAuthDataSecretKey.Spec.DataFilters[0].AltDestinations[0].Authorization.BodyData.SecretKeyRef.Key = "auth-data-secret-key-not-here"
+
+				err := dataFilters.Build(&drcBadAuthDataSecretKey)
+				Expect(err).To(HaveOccurred())
+			})
 
 			It("should error on TLSConfig secret not found", func() {
 				drcBadTLSConfigSecretName := drc

--- a/datareporter/v2/pkg/selector/selector_test.go
+++ b/datareporter/v2/pkg/selector/selector_test.go
@@ -34,59 +34,76 @@ var _ = Describe("Selector", func() {
 
 	BeforeEach(func() {
 		in = `{
-		"anonymousId": "22d09868-c4dd-4e22-9dcc-fb3dc3670592",
-		"context": {
-			"library": {
-				"name": "unknown",
-				"version": "unknown"
-			},
-			"protocols": {
-				"sourceId": "GDbmc9ffEx"
-			}
-		},
-		"event": "Account Contractual Usage",
-		"integrations": {
-		},
-		"messageId": "api-2FzZT63MioGiVg2ocBLkWgfYfaG",
-		"originalTimestamp": "2022-10-11T14:00:10.535087+00:00",
-		"properties": {
-			"accountId": "U***_I***_I***",
-			"accountIdType": "countryCode_ICN",
-			"accountPlan": "STL",
-			"chargePlanType": 2,
-			"daysToExpiration": 95,
-			"environment": "PRODUCTION",
-			"frequency": "Hourly",
-			"productId": "5737-M66",
-			"productTitle": "Maximo Application Suite",
-			"productVersion": "8.8.1",
-			"quantity": 450,
-			"quantityEntitled": 105,
-			"salesOrderNumber": "None",
-			"source": "10005a141d2b",
-			"unit": "AppPoints",
-			"unitDescription": "Account level AppPoint usage",
-			"unitMetadata": {
-				"data": {
-					"concurrent": 0,
-					"denied": 0,
-					"reserved": 450
+			"anonymousId": "f5d26e39-d421-4367-b623-4c8a7bbf6cbf",
+			"event": "Account Contractual Usage",
+			"properties": {
+				"accountId": "US_123456",
+				"accountIdType": "countryCode_ICN",
+				"accountPlan": "STL",
+				"chargePlanType": 2,
+				"daysToExpiration": 9999,
+				"environment": "PRODUCTION",
+				"eventId": "1234567890123",
+				"frequency": "Hourly",
+				"hyperscalerChannel": "ibm",
+				"hyperscalerFormat": "saas",
+				"hyperscalerProvider": "aws",
+				"instanceGuid": "123456789012-testcorp",
+				"instanceName": "",
+				"productCode": "WW1234",
+				"productCodeType": "WWPC",
+				"productId": "1234-M12",
+				"productTitle": "Test Application Suite",
+				"productVersion": "1.23.4",
+				"quantity": 123,
+				"salesOrderNumber": "1234X",
+				"source": "123456789abc",
+				"subscriptionId": "1234",
+				"tenantId": "1234",
+				"unit": "Points",
+				"unitDescription": "Points Description",
+				"unitMetadata": {
+					"data": {
+						"assist-Users": 0,
+						"core-Install": 100,
+						"health-AuthorizedUsers": 0,
+						"health-ConcurrentUsers": 0,
+						"health-MAS-Internal-Scores": 0,
+						"hputilities-MAS-AIO-Models": 0,
+						"hputilities-MAS-AIO-Scores": 0,
+						"hputilities-MAS-External-Scores": 0,
+						"manage-Database-replicas": 0,
+						"manage-Install": 150,
+						"manage-MAS-Base": 0,
+						"manage-MAS-Base-Authorized": 0,
+						"manage-MAS-Limited": 0,
+						"manage-MAS-Limited-Authorized": 0,
+						"manage-MAS-Premium": 0,
+						"manage-MAS-Premium-Authorized": 5,
+						"monitor-IOPoints": 0,
+						"monitor-KPIPoints": 0,
+						"predict-MAS-Models-Trained": 0,
+						"predict-MAS-Predictions-Count": 0,
+						"visualinspection-MAS-Images-Inferred": 0,
+						"visualinspection-MAS-Models-Trained": 0,
+						"visualinspection-MAS-Videos-Inferred": 0
+					},
+					"version": "1"
 				},
-				"version": "1"
-			}
-		},
-		"receivedAt": "2022-10-11T14:01:16.860Z",
-		"timestamp": "2022-10-11T14:00:10.535Z",
-		"type": "track",
-		"userId": "M***-1***-o***"
-	    }`
+				"UT30": "12BH3"
+			},
+			"timestamp": "2024-01-18T11:00:11.159442+00:00",
+			"type": "track",
+			"userId": "ABCid-123456789abc-owner",
+			"writeKey": "write-key"
+		}`
 
 		badin = `{unclosed`
 
 		// Match: true
 		jp1 = `$.properties.productId`
 		jp2 = `$[?($.properties.source != null)]`
-		jp3 = `$[?($.properties.unit == "AppPoints")]`
+		jp3 = `$[?($.properties.unit == "Points")]`
 		jp4 = `$[?($.properties.quantity >= 0)]`
 		jp5 = `$[?($.timestamp != null)]`
 

--- a/datareporter/v2/pkg/server/server_test.go
+++ b/datareporter/v2/pkg/server/server_test.go
@@ -27,56 +27,6 @@ import (
 
 var _ = Describe("Selector", func() {
 
-	/*
-		in := `{
-			"anonymousId": "22d09868-c4dd-4e22-9dcc-fb3dc3670592",
-			"context": {
-				"library": {
-					"name": "unknown",
-					"version": "unknown"
-				},
-				"protocols": {
-					"sourceId": "GDbmc9ffEx"
-				}
-			},
-			"event": "Account Contractual Usage",
-			"integrations": {
-			},
-			"messageId": "api-2FzZT63MioGiVg2ocBLkWgfYfaG",
-			"originalTimestamp": "2022-10-11T14:00:10.535087+00:00",
-			"properties": {
-				"accountId": "U***_I***_I***",
-				"accountIdType": "countryCode_ICN",
-				"accountPlan": "STL",
-				"chargePlanType": 2,
-				"daysToExpiration": 95,
-				"environment": "PRODUCTION",
-				"frequency": "Hourly",
-				"productId": "5737-M66",
-				"productTitle": "Maximo Application Suite",
-				"productVersion": "8.8.1",
-				"quantity": 450,
-				"quantityEntitled": 105,
-				"salesOrderNumber": "None",
-				"source": "10005a141d2b",
-				"unit": "AppPoints",
-				"unitDescription": "Account level AppPoint usage",
-				"unitMetadata": {
-					"data": {
-						"concurrent": 0,
-						"denied": 0,
-						"reserved": 450
-					},
-					"version": "1"
-				}
-			},
-			"receivedAt": "2022-10-11T14:01:16.860Z",
-			"timestamp": "2022-10-11T14:00:10.535Z",
-			"type": "track",
-			"userId": "M***-1***-o***"
-			}`
-	*/
-
 	BeforeEach(func() {
 
 	})
@@ -90,6 +40,7 @@ var _ = Describe("Selector", func() {
 				server.EventHandler(eventEngine, eventConfig, dataFilters, w, req)
 				resp := w.Result()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
 			})
 		})
 


### PR DESCRIPTION
Fix the datafilter possible double transform
Fix the datafilter goroutine/channel waiting
Log instead of err for failed httpclient assertation, such that httptest will function correctly
Enable auth tests
Update test data payload
Complete the test through the server handler
Enable logger for uploader
Fix parse for token/suffix to return proper string instead of json string