### PR TITLE
add debug logging

### DIFF
--- a/datareporter/v2/main.go
+++ b/datareporter/v2/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2/controllers"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2/pkg/datafilter"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2/pkg/events"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2/pkg/logger"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2/pkg/server"
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
@@ -210,6 +211,7 @@ func main() {
 	}()
 
 	rc := retryablehttp.NewClient()
+	rc.Logger = logger.NewRetryableHTTPLogger()
 	sc := rc.StandardClient() // *http.Client
 	dataFilters := datafilter.NewDataFilters(ctrl.Log.WithName("datafilter"), mgr.GetClient(), sc, eventEngine, config, &cc.ApiHandlerConfig)
 

--- a/datareporter/v2/pkg/logger/logger.go
+++ b/datareporter/v2/pkg/logger/logger.go
@@ -1,0 +1,80 @@
+// Copyright 2024 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-retryablehttp"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type logLevel int
+
+const (
+	logLevelWarn  logLevel = iota
+	logLevelInfo  logLevel = iota
+	logLevelDebug logLevel = iota
+)
+
+type logger struct {
+	logr.Logger
+}
+
+func (l logLevel) Level() int {
+	return int(l)
+}
+
+func NewRetryableHTTPLogger() *logger {
+	return &logger{
+		Logger: ctrl.Log.WithName("retryablehttp"),
+	}
+}
+
+var _ retryablehttp.LeveledLogger = (*logger)(nil)
+var _ retryablehttp.Logger = (*logger)(nil)
+
+func (l *logger) WithField(key string, value interface{}) *logger {
+	return l.WithFields(key, value)
+}
+
+func (l *logger) WithError(err error) *logger {
+	return l.WithFields("error", err)
+}
+
+func (l *logger) WithFields(keysAndValues ...interface{}) *logger {
+	newLogger := *l
+	newLogger.Logger = l.Logger.WithValues(keysAndValues...)
+	return &newLogger
+}
+
+func (l *logger) Error(msg string, keysAndValues ...interface{}) {
+	l.Logger.Error(nil, msg, keysAndValues...)
+}
+
+func (l *logger) Info(msg string, keysAndValues ...interface{}) {
+	l.Logger.V(logLevelInfo.Level()).Info(msg, keysAndValues...)
+}
+
+func (l *logger) Debug(msg string, keysAndValues ...interface{}) {
+	l.Logger.V(logLevelDebug.Level()).Info(msg, keysAndValues...)
+}
+
+func (l *logger) Warn(msg string, keysAndValues ...interface{}) {
+	l.Logger.V(logLevelWarn.Level()).Info(msg, keysAndValues...)
+}
+
+func (l *logger) Printf(msg string, keysAndValues ...interface{}) {
+	l.Logger.Info(msg, keysAndValues...)
+}

--- a/datareporter/v2/pkg/uploader/uploader.go
+++ b/datareporter/v2/pkg/uploader/uploader.go
@@ -194,7 +194,7 @@ func (u *Uploader) uploadToDest(destURL *url.URL, body []byte) (*http.Response, 
 		return nil, err
 	}
 
-	dReq.Header = u.destHeader
+	dReq.Header = u.destHeader.Clone()
 	if len(u.config.AuthDestHeader) != 0 && len(u.getAuthToken()) != 0 {
 		dReq.Header.Set(u.config.AuthDestHeader, u.config.AuthDestHeaderPrefix+u.getAuthToken())
 	}
@@ -225,7 +225,7 @@ func (u *Uploader) callAuth() (int, error) {
 		return http.StatusInternalServerError, err
 	}
 
-	aReq.Header = u.authHeader
+	aReq.Header = u.authHeader.Clone()
 
 	u.log.V(5).Info("authentication request", "url", aReq.URL, "header", aReq.Header, "body", string(u.authBodyData))
 

--- a/datareporter/v2/pkg/uploader/uploader.go
+++ b/datareporter/v2/pkg/uploader/uploader.go
@@ -155,6 +155,8 @@ func (u *Uploader) upload(destURL *url.URL, body []byte) (int, error) {
 
 	defer dResp.Body.Close()
 
+	u.log.V(5).Info("upload response", "url", dResp.Request.URL, "header", dResp.Header)
+
 	if dResp.StatusCode == http.StatusUnauthorized && u.authURL != nil {
 		// Request was not authorized, attempt to request a authorization token
 		statusCode, err := u.callAuth()
@@ -170,13 +172,15 @@ func (u *Uploader) upload(destURL *url.URL, body []byte) (int, error) {
 
 		defer adResp.Body.Close()
 
-		if adResp.StatusCode != http.StatusOK {
+		u.log.V(5).Info("upload response", "url", dResp.Request.URL, "header", dResp.Header)
+
+		if !(adResp.StatusCode >= 200 && adResp.StatusCode < 300) {
 			return adResp.StatusCode, errors.NewWithDetails(Non200Response, "url", u.destURL.String(), "statuscode", adResp.StatusCode)
 		}
 
 		return adResp.StatusCode, nil
 
-	} else if dResp.StatusCode != http.StatusOK {
+	} else if !(dResp.StatusCode >= 200 && dResp.StatusCode < 300) {
 		return dResp.StatusCode, errors.NewWithDetails(Non200Response, "url", u.destURL.String(), "statuscode", dResp.StatusCode)
 	}
 
@@ -194,7 +198,7 @@ func (u *Uploader) uploadToDest(destURL *url.URL, body []byte) (*http.Response, 
 	if len(u.config.AuthDestHeader) != 0 && len(u.getAuthToken()) != 0 {
 		dReq.Header.Set(u.config.AuthDestHeader, u.config.AuthDestHeaderPrefix+u.getAuthToken())
 	}
-
+	u.log.V(5).Info("upload request", "url", dReq.URL, "header", dReq.Header, "body", string(body))
 	return u.client.Do(dReq)
 }
 
@@ -223,6 +227,8 @@ func (u *Uploader) callAuth() (int, error) {
 
 	aReq.Header = u.authHeader
 
+	u.log.V(5).Info("authentication request", "url", aReq.URL, "header", aReq.Header, "body", string(u.authBodyData))
+
 	aResp, err := u.client.Do(aReq)
 	if err != nil {
 		return http.StatusInternalServerError, err
@@ -230,7 +236,9 @@ func (u *Uploader) callAuth() (int, error) {
 
 	defer aResp.Body.Close()
 
-	if aResp.StatusCode != http.StatusOK {
+	u.log.V(5).Info("authentication response", "url", aResp.Request.URL, "header", aResp.Header)
+
+	if !(aResp.StatusCode >= 200 && aResp.StatusCode < 300) {
 		return aResp.StatusCode, errors.NewWithDetails(Non200Response, "url", u.authURL.String(), "statuscode", aResp.StatusCode)
 	}
 
@@ -238,6 +246,8 @@ func (u *Uploader) callAuth() (int, error) {
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
+
+	u.log.V(5).Info("authentication response", "url", aResp.Request.URL, "header", aResp.Header, "body", string(aBody))
 
 	// If an expression is configured, parse the body for the first result as token
 	if u.authTokenExpr != nil {


### PR DESCRIPTION
- add logger to map retryablehttp to ctrl.Log
- add request tracing levels

modified logging levels are done via arg

```kubectl patch deployments.apps ibm-data-reporter-operator-controller-manager --type=json -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--zap-log-level=5" }]'```

- request header map should be copied not shallow