### PR TITLE
fix: npe, do not access nil resp on err

### DIFF
--- a/datareporter/v2/api/v1alpha1/componentconfig_types.go
+++ b/datareporter/v2/api/v1alpha1/componentconfig_types.go
@@ -95,7 +95,7 @@ func init() {
 }
 
 func NewComponentConfig() *ComponentConfig {
-	handlerDuration, _ := time.ParseDuration("3s")
+	handlerDuration, _ := time.ParseDuration("30s")
 	accMemLimit, _ := resource.ParseQuantity("50mi")
 	maxFlushTimeout, _ := time.ParseDuration("300s")
 

--- a/datareporter/v2/config/crd/bases/marketplace.redhat.com_componentconfigs.yaml
+++ b/datareporter/v2/config/crd/bases/marketplace.redhat.com_componentconfigs.yaml
@@ -219,11 +219,11 @@ spec:
             description: ComponentConfigStatus defines the observed state of ComponentConfig
             type: object
           tlsConfig:
-            description: TLSConfig refers to TLS configuration
+            description: TLSConfig refers to TLS configuration options.
             properties:
               caCerts:
                 description: CACertsSecret refers to a list of secret keys that contains
-                  CA certificates in PEM. tls.Config.RootCAs
+                  CA certificates in PEM. crypto/tls Config.RootCAs.
                 items:
                   description: SecretKeySelector selects a key of a Secret.
                   properties:
@@ -245,18 +245,17 @@ spec:
                 type: array
               certificates:
                 description: Certificates refers to a list of X509KeyPairs consisting
-                  of the client public/private key. tls.Config.Certificates
+                  of the client public/private key. crypto/tls Config.Certificates.
                 items:
                   description: Certificate refers to the the X509KeyPair, consisting
-                    of the secrets containing the key and cert pem
+                    of the secrets containing the key and cert pem.
                   properties:
                     clientCert:
-                      description: ClientCert refers to the secret that contains the
-                        client cert PEM
+                      description: ClientCert refers to the SecretKeyRef that contains
+                        the client cert PEM
                       properties:
                         secretKeyRef:
-                          description: ClientCert refers to the secret that contains
-                            the client cert PEM
+                          description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -276,12 +275,11 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     clientKey:
-                      description: ClientKey refers to the secret that contains the
-                        client key PEM
+                      description: ClientKey refers to the SecretKeyRef that contains
+                        the client key PEM
                       properties:
                         secretKeyRef:
-                          description: ClientCert refers to the secret that contains
-                            the client cert PEM
+                          description: SecretKeySelector selects a key of a Secret.
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -303,17 +301,19 @@ spec:
                   type: object
                 type: array
               cipherSuites:
-                description: CipherSuites is a list of enabled cipher suites. tls.Config.CipherSuites
+                description: CipherSuites is a list of enabled cipher suites. crypto/tls
+                  Config.CipherSuites.
                 items:
                   type: string
                 type: array
               insecureSkipVerify:
                 description: If true, skips creation of TLSConfig with certs and creates
-                  an empty TLSConfig. tls.Config.InsecureSkipVerify (Defaults to false)
+                  an empty TLSConfig. crypto/tls Config.InsecureSkipVerify (Defaults
+                  to false).
                 type: boolean
               minVersion:
                 description: MinVersion contains the minimum TLS version that is acceptable
-                  tls.Config.MinVersion
+                  crypto/tls Config.MinVersion.
                 type: string
             type: object
         type: object

--- a/datareporter/v2/config/crd/bases/marketplace.redhat.com_datareporterconfigs.yaml
+++ b/datareporter/v2/config/crd/bases/marketplace.redhat.com_datareporterconfigs.yaml
@@ -33,51 +33,53 @@ spec:
           metadata:
             type: object
           spec:
-            description: DataReporterConfigSpec defines the desired state of DataReporterConfig
+            description: DataReporterConfigSpec defines the desired state of DataReporterConfig.
             properties:
               confirmDelivery:
                 description: 'ConfirmDelivery configures the api handler. Takes priority
-                  over configuring ComponentConfig true: skips the EventEngine accumulator
-                  and generates 1 report with 1 event The handler will wait for 200
-                  OK for DataService delivery before returning 200 OK false: enters
+                  over configuring ComponentConfig. true: skips the EventEngine accumulator
+                  and generates 1 report with 1 event. The handler will wait for 200
+                  OK for DataService delivery before returning 200 OK. false: enters
                   the event into the EventEngine accumulator and generates 1 report
-                  with N events The handler will return a 200 OK for DataService delivery
-                  as long as the event json is valid'
+                  with N events. The handler will return a 200 OK for DataService
+                  delivery as long as the event json is valid.'
                 type: boolean
               dataFilters:
-                description: DataFilter to match incoming event payload against The
-                  first DataFilter match in the array based on the Selector will be
-                  applied
+                description: DataFilter to match incoming event payload against. The
+                  first Selector match in the DataFilters array will be applied.
                 items:
                   description: DataFilter defines json transformation and alternate
-                    event payload destinations based on selector criteria No Selector
-                    indicates match all
+                    event payload destinations based on selector criteria. No Selector
+                    indicates match all.
                   properties:
                     altDestinations:
                       items:
                         description: Destination defines an additional endpoint to
-                          forward a transformed event payload to
+                          forward a transformed event payload to.
                         properties:
                           authorization:
                             description: Sets an optional authorization endpoint to
-                              first request a token from
+                              first request a token from. The Authorization endpoint
+                              is called if the call to the destination URL results
+                              in a 403.
                             properties:
                               authDestHeader:
                                 description: Sets the additional header map key to
-                                  set on the Destination header ("Authorization")
+                                  set on the Destination header ("Authorization").
                                 type: string
                               authDestHeaderPrefix:
-                                description: 'authDestHeaderPrefix: the additional
+                                description: 'AuthDestHeaderPrefix: the additional
                                   prefix map string value to set on the destHeader
-                                  ("Bearer ")'
+                                  ("Bearer ").'
                                 type: string
                               bodyData:
-                                description: secret containing body data to POST to
-                                  authorization endpoint (apikey)
+                                description: BodyData refers to a SecretKeyRef containing
+                                  body data to POST to authorization endpoint, such
+                                  as an api key.
                                 properties:
                                   secretKeyRef:
-                                    description: ClientCert refers to the secret that
-                                      contains the client cert PEM
+                                    description: SecretKeySelector selects a key of
+                                      a Secret.
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -100,11 +102,12 @@ spec:
                                 type: object
                               header:
                                 description: Sets the sources of the headers to pass
-                                  to the client
+                                  to the client when calling the authorization URL.
                                 properties:
                                   secret:
                                     description: Sets the name of the secret that
-                                      contains the headers
+                                      contains the headers. Secret map key/value pairs
+                                      will be used for the header.
                                     properties:
                                       name:
                                         description: 'Name of the referent. More info:
@@ -116,22 +119,24 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               tokenExpr:
-                                description: 'tokenExpr: jsonpath expression to parse
-                                  the response for the authorization token'
+                                description: TokenExpr is a jsonpath expression used
+                                  to parse the authorization response in order to
+                                  extract the token.
                                 type: string
                               url:
-                                description: url is the destination endpoint (https://hostname:port/path).
+                                description: URL is the authorization endpoint (https://hostname:port/path).
                                 type: string
                             required:
                             - url
                             type: object
                           header:
                             description: Sets the sources of the headers to pass to
-                              the client
+                              the client when calling the destination URL.
                             properties:
                               secret:
                                 description: Sets the name of the secret that contains
-                                  the headers
+                                  the headers. Secret map key/value pairs will be
+                                  used for the header.
                                 properties:
                                   name:
                                     description: 'Name of the referent. More info:
@@ -143,9 +148,8 @@ spec:
                                 x-kubernetes-map-type: atomic
                             type: object
                           transformer:
-                            description: Transformer defines the type of transformer
-                              to use, and where to load the transformation configuration
-                              from
+                            description: Transformer refers to the Transformer to
+                              apply.
                             properties:
                               configMapKeyRef:
                                 description: configMapKeyRef refers to the transformation
@@ -174,12 +178,12 @@ spec:
                                 type: string
                             type: object
                           url:
-                            description: url is the destination endpoint (https://hostname:port/path).
+                            description: URL is the destination endpoint (https://hostname:port/path).
                             type: string
                           urlSuffixExpr:
-                            description: 'urlSuffixExpr: jsonpath expression to parse
-                              the event for a variable suffix to the destination url
-                              https://example/path/{URLSuffixExprResult}'
+                            description: URLSuffixExpr is a jsonpath expression used
+                              to parse the event. The result is appended to the destination
+                              URL. https://example/path/{URLSuffixExprResult}
                             type: string
                         required:
                         - url
@@ -189,26 +193,26 @@ spec:
                       type: string
                     selector:
                       description: Selector defines criteria for matching incoming
-                        event payload
+                        event payload.
                       properties:
                         matchExpressions:
-                          description: matchExpressions is a list of jsonpath expressions
-                            to match the selector, all jsonpath expressions must produce
-                            a result (AND)
+                          description: MatchExpressions is a list of jsonpath expressions.
+                            To match the Selector, all jsonpath expressions must produce
+                            a result (AND).
                           items:
                             type: string
                           type: array
                         matchUsers:
-                          description: matchUsers is a list of users that the dataFilter
-                            applies to. If matchUsers is not specified, the dataFilter
-                            applies to all users
+                          description: MatchUsers is a list of users that the dataFilter
+                            applies to. If MatchUsers is not specified, the DataFilter
+                            applies to all users.
                           items:
                             type: string
                           type: array
                       type: object
                     transformer:
                       description: Transformer defines the type of transformer to
-                        use, and where to load the transformation configuration from
+                        use, and where to load the transformation configuration from.
                       properties:
                         configMapKeyRef:
                           description: configMapKeyRef refers to the transformation
@@ -238,11 +242,11 @@ spec:
                 type: array
               tlsConfig:
                 description: TLSConfig specifies TLS configuration parameters for
-                  outbound https requests from the client
+                  outbound https requests from the client.
                 properties:
                   caCerts:
                     description: CACertsSecret refers to a list of secret keys that
-                      contains CA certificates in PEM. tls.Config.RootCAs
+                      contains CA certificates in PEM. crypto/tls Config.RootCAs.
                     items:
                       description: SecretKeySelector selects a key of a Secret.
                       properties:
@@ -265,18 +269,17 @@ spec:
                     type: array
                   certificates:
                     description: Certificates refers to a list of X509KeyPairs consisting
-                      of the client public/private key. tls.Config.Certificates
+                      of the client public/private key. crypto/tls Config.Certificates.
                     items:
                       description: Certificate refers to the the X509KeyPair, consisting
-                        of the secrets containing the key and cert pem
+                        of the secrets containing the key and cert pem.
                       properties:
                         clientCert:
-                          description: ClientCert refers to the secret that contains
-                            the client cert PEM
+                          description: ClientCert refers to the SecretKeyRef that
+                            contains the client cert PEM
                           properties:
                             secretKeyRef:
-                              description: ClientCert refers to the secret that contains
-                                the client cert PEM
+                              description: SecretKeySelector selects a key of a Secret.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -297,12 +300,11 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientKey:
-                          description: ClientKey refers to the secret that contains
+                          description: ClientKey refers to the SecretKeyRef that contains
                             the client key PEM
                           properties:
                             secretKeyRef:
-                              description: ClientCert refers to the secret that contains
-                                the client cert PEM
+                              description: SecretKeySelector selects a key of a Secret.
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -326,24 +328,24 @@ spec:
                     type: array
                   cipherSuites:
                     description: CipherSuites is a list of enabled cipher suites.
-                      tls.Config.CipherSuites
+                      crypto/tls Config.CipherSuites.
                     items:
                       type: string
                     type: array
                   insecureSkipVerify:
                     description: If true, skips creation of TLSConfig with certs and
-                      creates an empty TLSConfig. tls.Config.InsecureSkipVerify (Defaults
-                      to false)
+                      creates an empty TLSConfig. crypto/tls Config.InsecureSkipVerify
+                      (Defaults to false).
                     type: boolean
                   minVersion:
                     description: MinVersion contains the minimum TLS version that
-                      is acceptable tls.Config.MinVersion
+                      is acceptable crypto/tls Config.MinVersion.
                     type: string
                 type: object
               userConfig:
                 items:
                   description: UserConfig defines additional metadata added to a specified
-                    users report
+                    users report.
                   properties:
                     metadata:
                       additionalProperties:

--- a/datareporter/v2/config/manager/component_config.yaml
+++ b/datareporter/v2/config/manager/component_config.yaml
@@ -1,7 +1,7 @@
 apiVersion: marketplace.redhat.com/v1alpha1
 kind: ComponentConfig
 apiHandlerConfig:
-  handlerTimeout: "3s"
+  handlerTimeout: "30s"
 eventHandlerConfig:
   memoryLimit: "50Mi"
   maxFlushTimeout: "300s"

--- a/datareporter/v2/config/manager/kustomization.yaml
+++ b/datareporter/v2/config/manager/kustomization.yaml
@@ -6,3 +6,10 @@ configMapGenerator:
 - files:
   - component_config.yaml
   name: component-config
+images:
+- name: ibm-data-reporter-operator
+  newName: image-registry.openshift-image-registry.svc:5000/openshift/ibm-data-reporter-operator
+  newTag: tag-1709851136
+commonAnnotations:
+  operatorImage: image-registry.openshift-image-registry.svc:5000/openshift/ibm-data-reporter-operator:tag-1709851136
+  rbacProxyImage: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14

--- a/datareporter/v2/config/manager/kustomization.yaml
+++ b/datareporter/v2/config/manager/kustomization.yaml
@@ -6,10 +6,3 @@ configMapGenerator:
 - files:
   - component_config.yaml
   name: component-config
-images:
-- name: ibm-data-reporter-operator
-  newName: image-registry.openshift-image-registry.svc:5000/openshift/ibm-data-reporter-operator
-  newTag: tag-1709851136
-commonAnnotations:
-  operatorImage: image-registry.openshift-image-registry.svc:5000/openshift/ibm-data-reporter-operator:tag-1709851136
-  rbacProxyImage: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14

--- a/datareporter/v2/pkg/datafilter/datafilter.go
+++ b/datareporter/v2/pkg/datafilter/datafilter.go
@@ -85,8 +85,8 @@ func NewDataFilters(
 // Updates the httpClient transport
 func (d *DataFilters) Build(drc *v1alpha1.DataReporterConfig) error {
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	// Update API Handler
 	if drc.Spec.ConfirmDelivery != nil {

--- a/datareporter/v2/pkg/uploader/uploader.go
+++ b/datareporter/v2/pkg/uploader/uploader.go
@@ -167,7 +167,7 @@ func (u *Uploader) upload(destURL *url.URL, body []byte) (int, error) {
 		// With new token, try destination again
 		adResp, err := u.uploadToDest(destURL, body)
 		if err != nil {
-			return adResp.StatusCode, err
+			return http.StatusInternalServerError, err
 		}
 
 		defer adResp.Body.Close()


### PR DESCRIPTION
- update the default handler timeout, at prev 3s timeout would occur if 
  - controller reconcile took some time, locks the datafilter to update it blocking new requests
  - upstream destination responds slowly
- commit updated generated bases with updated description
- Perf: Maintain a watch predicate for secrets/configmaps that refer only to objects found in the DataReporterConfig. Do not reconcile on arbitrary secrets/configmaps as each reconcilation causes datafilter lock and request delay.
- Fix datafilter lock, should be write lock
- Don't read response code on error, leads to NPE
