### PR TITLE
fix: update alt namespace rbac details

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,22 @@ The Operators and their components support running under the OpenShift Container
 ### Installation Namespace and ClusterRoleBinding requirements
 
 The IBM Metrics Operator components require specific ClusterRoleBindings.
-- The metric-state component requires a ClusterRoleBinding for the the `view` ClusterRole. 
-- The reporter component requires a ClusterRoleBinding for the the `cluster-monitoring-view` ClusterRole. 
+- The metric-state component requires a ClusterRoleBinding for the the `view` ClusterRole.
+  - Ability to read non-sensitive CustomResources. 
+  - The `view` ClusterRole dynamically adds new CustomResourceDefinitions.
+- The operator & reporter component requires a ClusterRoleBinding for the the `cluster-monitoring-view` ClusterRole.
+  - Ability to view Prometheus metrics. 
+  - The underlying ClusterRole RBAC often updated between OpenShift versions.
 
-Due to limitations of Operator Lifecycle Manager (OLM), this ClusterRoleBinding can not be provided automatically for arbitrary installation target namespaces.
+Due to limitations of Operator Lifecycle Manager (OLM), this ClusterRoleBinding can not be provided dynamically for arbitrary installation target namespaces.
 
-A ClusterRoleBinding is included for installation to the default namespace of `redhat-marketplace`, and namespaces `openshift-redhat-marketplace`, `ibm-common-services`.
+A static ClusterRoleBinding is included for installation to the default namespace of `redhat-marketplace`, and namespaces `openshift-redhat-marketplace`, `ibm-common-services`.
 
-To update the ClusterRoleBindings for installation to an alternate namespace
+To create the ClusterRoleBindings for installation to an alternate namespace
 ```
-oc patch clusterrolebinding ibm-metrics-operator-metric-state-view-binding --type='json' -p='[{"op": "add", "path": "/subjects/1", "value": {"kind": "ServiceAccount", "name": "ibm-metrics-operator-metric-state","namespace": "NAMESPACE" }}]'
-
-oc patch clusterrolebinding ibm-metrics-operator-reporter-cluster-monitoring-binding --type='json' -p='[{"op": "add", "path": "/subjects/1", "value": {"kind": "ServiceAccount", "name": "ibm-metrics-operator-reporter","namespace": "NAMESPACE" }}]'
+oc project INSTALL-NAMESPACE
+oc adm policy add-cluster-role-to-user view -z ibm-metrics-operator-metric-state
+oc adm policy add-cluster-role-to-user cluster-monitoring-view -z ibm-metrics-operator-controller-manager,ibm-metrics-operator-reporter
 ```
 
 ### Metric State scoping requirements

--- a/v2/README.md
+++ b/v2/README.md
@@ -197,18 +197,22 @@ The Operators and their components support running under the OpenShift Container
 ### Installation Namespace and ClusterRoleBinding requirements
 
 The IBM Metrics Operator components require specific ClusterRoleBindings.
-- The metric-state component requires a ClusterRoleBinding for the the `view` ClusterRole. 
-- The reporter component requires a ClusterRoleBinding for the the `cluster-monitoring-view` ClusterRole. 
+- The metric-state component requires a ClusterRoleBinding for the the `view` ClusterRole.
+  - Ability to read non-sensitive CustomResources. 
+  - The `view` ClusterRole dynamically adds new CustomResourceDefinitions.
+- The operator & reporter component requires a ClusterRoleBinding for the the `cluster-monitoring-view` ClusterRole.
+  - Ability to view Prometheus metrics. 
+  - The underlying ClusterRole RBAC often updated between OpenShift versions.
 
-Due to limitations of Operator Lifecycle Manager (OLM), this ClusterRoleBinding can not be provided automatically for arbitrary installation target namespaces.
+Due to limitations of Operator Lifecycle Manager (OLM), this ClusterRoleBinding can not be provided dynamically for arbitrary installation target namespaces.
 
-A ClusterRoleBinding is included for installation to the default namespace of `redhat-marketplace`, and namespaces `openshift-redhat-marketplace`, `ibm-common-services`.
+A static ClusterRoleBinding is included for installation to the default namespace of `redhat-marketplace`, and namespaces `openshift-redhat-marketplace`, `ibm-common-services`.
 
-To update the ClusterRoleBindings for installation to an alternate namespace
+To create the ClusterRoleBindings for installation to an alternate namespace
 ```
-oc patch clusterrolebinding ibm-metrics-operator-metric-state-view-binding --type='json' -p='[{"op": "add", "path": "/subjects/1", "value": {"kind": "ServiceAccount", "name": "ibm-metrics-operator-metric-state","namespace": "NAMESPACE" }}]'
-
-oc patch clusterrolebinding ibm-metrics-operator-reporter-cluster-monitoring-binding --type='json' -p='[{"op": "add", "path": "/subjects/1", "value": {"kind": "ServiceAccount", "name": "ibm-metrics-operator-reporter","namespace": "NAMESPACE" }}]'
+oc project INSTALL-NAMESPACE
+oc adm policy add-cluster-role-to-user view -z ibm-metrics-operator-metric-state
+oc adm policy add-cluster-role-to-user cluster-monitoring-view -z ibm-metrics-operator-controller-manager,ibm-metrics-operator-reporter
 ```
 
 ### Metric State scoping requirements

--- a/v2/config/rbac/role_binding.yaml
+++ b/v2/config/rbac/role_binding.yaml
@@ -12,19 +12,6 @@ subjects:
   namespace: system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: manager-cluster-monitoring-view-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-monitoring-view
-subjects:
-- kind: ServiceAccount
-  name: controller-manager
-  namespace: system
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manager-rolebinding

--- a/v2/config/rbac_classic/role_binding.yaml
+++ b/v2/config/rbac_classic/role_binding.yaml
@@ -37,3 +37,22 @@ roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view
   apiGroup: rbac.authorization.k8s.io
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manager-cluster-monitoring-binding
+subjects:
+- kind: ServiceAccount
+  name: ibm-data-reporter-operator-controller-manager
+  namespace: openshift-redhat-marketplace
+- kind: ServiceAccount
+  name: ibm-data-reporter-operator-controller-manager
+  namespace: redhat-marketplace
+- kind: ServiceAccount
+  name: ibm-data-reporter-operator-controller-manager
+  namespace: ibm-common-services
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- move the ClusterRoleBinding for manager to rbac_classic, and correctly include the additional static namespaces
- update the instructions to use the general `oc adm` command to create a new binding. updating the existing binding could be overwritten by an upgrade.
