### PR TITLE
fix: restore /v1/event respones body

### DIFF
--- a/datareporter/v2/pkg/server/server.go
+++ b/datareporter/v2/pkg/server/server.go
@@ -110,6 +110,8 @@ func EventHandler(eventEngine *events.EventEngine, eventConfig *events.Config, d
 
 	// Event was sent to DataService successfully, and any DataFilter destinations
 	w.WriteHeader(http.StatusOK)
+	out, _ := json.Marshal(event)
+	w.Write(out)
 }
 
 type StatusResponse struct {


### PR DESCRIPTION
restore sending the event body back as part of the /v1/event POST response
even though the response is useless, changing the behavior was breaking, since some consumers are checking the response body

Prior Release:
https://github.com/redhat-marketplace/redhat-marketplace-operator/blob/2.13.5/datareporter/v2/pkg/server/server.go#L98-L99
