### PR TITLE
fix: use swc domain, update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IBM&reg; Red Hat Marketplace Operators
+# IBM&reg; IBM Software Central Operators
 
 | Branch  |                                                                                                            Builds                                                                                                             |
 | :-----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
@@ -7,35 +7,24 @@
 
 ## Description
 
-The Red Hat Marketplace Operators are a collection of operators for reporting workload metrics and integrating product install lifecycle through [https://marketplace.redhat.com](https://marketplace.redhat.com).
+The IBM Software Central Operators (formerly Red Hat Marketplace Operators) are a collection of operators for reporting workload metrics and integrating product install lifecycle through [https://swc.saas.ibm.com](https://swc.saas.ibm.com).
 
 ### [IBM Metrics Operator](v2/README.md)
 
-The [IBM Metrics Operator](v2/README.md) is used to meter workloads and report usage from Prometheus on an OpenShift cluster, and reports it to Red Hat Marketplace.
+The [IBM Metrics Operator](v2/README.md) is used to meter workloads and report usage from Prometheus on an OpenShift cluster, and reports it to IBM Software Central.
 
 ### [IBM Data Reporter Operator](datareporter/v2/README.md)
 
-The [IBM Data Reporter Operator](datareporter/v2/README.md) is used as a push event interface into the IBM Metrics Operator's data-service, for reporting to Red Hat Marketplace.
+The [IBM Data Reporter Operator](datareporter/v2/README.md) is used as a push event interface into the IBM Metrics Operator's data-service, for reporting to IBM Software Central.
 
 ### [Red Hat Marketplace Deployment Operator by IBM](deployer/v2/README.md)
 
-The [Red Hat Marketplace Deployment Operator by IBM](deployer/v2/README.md) is used for integrating cluster and operator subscription management on an OpenShift cluster via [https://marketplace.redhat.com](https://marketplace.redhat.com).
+The [Red Hat Marketplace Deployment Operator by IBM](deployer/v2/README.md) is used for integrating cluster and operator subscription management on an OpenShift cluster via [https://swc.saas.ibm.com](https://swc.saas.ibm.com).
 
 
 ## Installation
 
-### **Upgrade Notice**
-
-The Red Hat Marketplace Operator metering and deployment functionalities have been separated into two operators.
-  - The metering functionality is included in the IBM Metrics Operator
-    - Admin level functionality and permissions are removed from the IBM Metrics Operator
-    - ClusterServiceVersion/ibm-metrics-operator
-  - The deployment functionality remains as part of the Red Hat Marketplace Deployment Operator
-    - The Red Hat Marketplace Deployment Operator prerequisites the IBM Metrics Operator
-    - Some admin level RBAC permissions are required for deployment functionality
-    - ClusterServiceVersion/redhat-marketplace-operator
-
-Full registration and visibility of usage metrics on [https://marketplace.redhat.com](https://marketplace.redhat.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -139,7 +128,7 @@ spec:
 
 ### Installing
 
-For installation and configuration see the [Red Hat Marketplace documentation](https://marketplace.redhat.com/en-us/documentation/getting-started/).
+For installation and configuration see the [Red Hat Marketplace documentation](https://swc.saas.ibm.com/en-us/documentation/getting-started/).
 
 
 ## Additional information
@@ -198,7 +187,7 @@ This is a high level visual representation of how the operators interact with Pr
 
 ### Documentation
 
-[Red Hat Marketplace](https://marketplace.redhat.com/en-us/documentation)
+[Red Hat Marketplace](https://swc.saas.ibm.com/en-us/documentation)
 
 [Wiki](https://github.com/redhat-marketplace/redhat-marketplace-operator/wiki/Home)
  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IBM&reg; IBM Software Central Operators
+# IBM&reg; IBM Software Central & Red Hat Marketplace Operators
 
 | Branch  |                                                                                                            Builds                                                                                                             |
 | :-----: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
@@ -7,7 +7,7 @@
 
 ## Description
 
-The IBM Software Central Operators (formerly Red Hat Marketplace Operators) are a collection of operators for reporting workload metrics and integrating product install lifecycle through [https://swc.saas.ibm.com](https://swc.saas.ibm.com).
+The operators provide functionality for reporting workload metrics and integrating product install lifecycle through [https://swc.saas.ibm.com](https://swc.saas.ibm.com).
 
 ### [IBM Metrics Operator](v2/README.md)
 
@@ -15,16 +15,20 @@ The [IBM Metrics Operator](v2/README.md) is used to meter workloads and report u
 
 ### [IBM Data Reporter Operator](datareporter/v2/README.md)
 
-The [IBM Data Reporter Operator](datareporter/v2/README.md) is used as a push event interface into the IBM Metrics Operator's data-service, for reporting to IBM Software Central.
+The [IBM Data Reporter Operator](datareporter/v2/README.md) provides a push event interface into the IBM Metrics Operator's data-service, for reporting metrics to IBM Software Central.
 
 ### [Red Hat Marketplace Deployment Operator by IBM](deployer/v2/README.md)
 
 The [Red Hat Marketplace Deployment Operator by IBM](deployer/v2/README.md) is used for integrating cluster and operator subscription management on an OpenShift cluster via [https://swc.saas.ibm.com](https://swc.saas.ibm.com).
 
+### Note
+
+Usage metrics may be monitored through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) with only IBM Metrics Operator and a Red Hat Marketplace account, and does not require Red Hat Marketplace Deployment Operator.
+
+Full cluster registration and software lifecycle management through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+
 
 ## Installation
-
-Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -51,7 +55,7 @@ Minimum system resources required:
 | --------- | ----------- | ----------- | --------- | ----- |
 | **[Openshift User Workload Monitoring](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)** |          1  |     0.1       | 2x40        |   2    |
 
-Multiple nodes are required to provide pod scheduling for high availability for Red Hat Marketplace Data Service and Prometheus.
+Multiple nodes are required to provide pod scheduling for high availability for IBM Metrics Operator Data Service and Prometheus.
 
 The IBM Metrics Operator automatically creates 3 x 1Gi PersistentVolumeClaims to store reports as part of the data service, with _ReadWriteOnce_ access mode. Te PersistentVolumeClaims are automatically created by the ibm-metrics-operator after creating a `redhat-marketplace-pull-secret` and accepting the license in `marketplaceconfig`.
 
@@ -126,9 +130,9 @@ spec:
     name: rhm-data-service-rhm-data-service-0
 ```
 
-### Installing
+### Getting Started with the platform
 
-For installation and configuration see the [Red Hat Marketplace documentation](https://swc.saas.ibm.com/en-us/documentation/getting-started/).
+To get started with the platform, see the [documentation](https://swc.saas.ibm.com/en-us/documentation/getting-started/).
 
 
 ## Additional information
@@ -181,13 +185,13 @@ A limitation is that the `config` elements are only appended to the operands. Th
 
 ### Operators Visual Diagram
 
-This is a high level visual representation of how the operators interact with Prometheus, CustomResources, with each other, and with Red Hat Marketplace.
+This is a high level visual representation of how the operators interact with Prometheus, CustomResources, with each other, and with IBM Software Central.
 
 ![Operators Visual Diagram](diagram.png)
 
 ### Documentation
 
-[Red Hat Marketplace](https://swc.saas.ibm.com/en-us/documentation)
+[IBM Software Central](https://swc.saas.ibm.com/en-us/documentation)
 
 [Wiki](https://github.com/redhat-marketplace/redhat-marketplace-operator/wiki/Home)
  

--- a/datareporter/v2/README.md
+++ b/datareporter/v2/README.md
@@ -2,11 +2,11 @@
 
 # Introduction
 
-The IBM Data Reporter Operator accepts events and transforms them into reports submitted to the Data Service of the IBM Metrics Operator.
+The IBM Data Reporter Operator accepts events and transforms them into reports submitted to the IBM Metrics Operator Data Service.
 
 # Details
 
-The IBM Data Reporter Operator deploys a service that exposes an endpoint to which callers can send raw json event data. The event data is transformed into a report and is sent to the IBM Metrics Operator's Data Service. The IBM Metrics Operator Data Service periodically uploads the reports to Red Hat Marketplace. It can also filter, transform and forward events to alternate endpoints.
+The IBM Data Reporter Operator deploys a service that provides an endpoint to which callers can send raw json event data. The event data is transformed into a report and is sent to the IBM Metrics Operator's Data Service. The IBM Metrics Operator Data Service periodically uploads the reports to IBM Software Central. It can also filter, transform and forward events to alternate endpoints.
 
 ## Prerequisites
 

--- a/deployer/v2/README.md
+++ b/deployer/v2/README.md
@@ -1,8 +1,10 @@
-The Red Hat Marketplace Deployment Operator by IBM provides cluster and operator management for Red Hat Marketplace customers.
+The Red Hat Marketplace Deployment Operator by IBM provides cluster and operator management for IBM Software Central and Red Hat Marketplace customers.
 ### **Important Note**
 A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [swc.saas.ibm.com](https://swc.saas.ibm.com).
 
-Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+Usage metrics may be monitored through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) with only IBM Metrics Operator and a Red Hat Marketplace account, and does not require Red Hat Marketplace Deployment Operator.
+
+Full cluster registration and software lifecycle management through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -61,14 +63,14 @@ The operator releases adhere to semantic versioning and provides a seamless upgr
     ```
 
 ### Installation
-1. Create or get your pull secret from [Red Hat Marketplace](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
+1. Create or get your [pull secret](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
 2. Install the IBM Metrics Operator and Red Hat Marketplace Deployment Operator
 3. Create a Kubernetes secret in the installed namespace with the name `redhat-marketplace-pull-secret` and key `PULL_SECRET` with the value of the Red hat Marketplace Pull Secret.
     ```sh
     # Replace ${PULL_SECRET} with your secret from Red Hat Marketplace
-    oc create secret generic redhat-marketplace-pull-secret -n  redhat-marketplace --from-literal=PULL_SECRET=${PULL_SECRET}
+    oc create secret generic redhat-marketplace-pull-secret -n redhat-marketplace --from-literal=PULL_SECRET=${PULL_SECRET}
     ```
-4. Use of the Red Hat Marketplace platform is governed by the:
+4. Use of the platform is governed by the:
 
     [IBM Cloud Services Agreement](https://www.ibm.com/support/customer/csol/terms/?id=Z126-6304_WS&_ga=2.116312197.2046730452.1684328846-812467790.1684328846) (or other base agreement between you and IBM such as a [Passport Advantage Agreement](https://www.ibm.com/software/passportadvantage/pa_agreements.html?_ga=2.116312197.2046730452.1684328846-812467790.1684328846)) and the [Service Description for the Red Hat Marketplace](https://www.ibm.com/support/customer/csol/terms/?id=i126-8719&_ga=2.83289621.2046730452.1684328846-812467790.1684328846).
 
@@ -81,7 +83,7 @@ The operator releases adhere to semantic versioning and provides a seamless upgr
     These steps require `oc`, `jq`, and `base64` to be available on your machine.
 
     ```sh
-    # Create the docker pull secret file using your PULL_SECRET from IBM Software Central.
+    # Create the docker pull secret file using your pull secret.
     # Store it in a file called entitledregistryconfigjson.
     oc create secret docker-registry entitled-registry --docker-server=registry.marketplace.redhat.com --docker-username "cp" --docker-password "${PULL_SECRET}" --dry-run=client --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode > entitledregistryconfigjson
     # Get the current global secrets on the cluster and store it as a file named dockerconfigjson
@@ -132,7 +134,7 @@ A limitation is that the `config` elements are only appended to the operands. Th
 You can find our documentation [here.](https://swc.saas.ibm.com/en-us/documentation/)
 
 ### Getting help
-If you encounter any issues while using Red Hat Marketplace operator, you can create an issue on our [Github
+If you encounter any issues while using the operators, you can create an issue on our [Github
 repo](https://github.com/redhat-marketplace/redhat-marketplace-operator) for bugs, enhancements, or other requests. You can also visit our main page and
 review our [support](https://swc.saas.ibm.com/en-us/support) and [documentation](https://swc.saas.ibm.com/en-us/documentation/).
 

--- a/deployer/v2/README.md
+++ b/deployer/v2/README.md
@@ -1,19 +1,8 @@
 The Red Hat Marketplace Deployment Operator by IBM provides cluster and operator management for Red Hat Marketplace customers.
 ### **Important Note**
-A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [marketplace.redhat.com](https://marketplace.redhat.com).
+A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [swc.saas.ibm.com](https://swc.saas.ibm.com).
 
-### **Upgrade Notice**
-
-The Red Hat Marketplace Operator metering and deployment functionality have been separated into two operators.
-  - The deployment functionality remains as part of this Red Hat Marketplace Deployment Operator
-    - The Red Hat Marketplace Deployment Operator prerequisites the IBM Metrics Operator
-    - Admin level functionality and permissions are required for deployment functionality
-    - ClusterServiceVersion/redhat-marketplace-operator
-  - The metering functionality is included in the IBM Metrics Operator
-    - Admin level functionality and permissions are removed from the IBM Metrics Operator
-    - ClusterServiceVersion/ibm-metrics-operator
-
-Full registration and visibility of usage metrics on [https://marketplace.redhat.com](https://marketplace.redhat.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -72,7 +61,7 @@ The operator releases adhere to semantic versioning and provides a seamless upgr
     ```
 
 ### Installation
-1. Create or get your pull secret from [Red Hat Marketplace](https://marketplace.redhat.com/en-us/documentation/clusters#get-pull-secret).
+1. Create or get your pull secret from [Red Hat Marketplace](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
 2. Install the IBM Metrics Operator and Red Hat Marketplace Deployment Operator
 3. Create a Kubernetes secret in the installed namespace with the name `redhat-marketplace-pull-secret` and key `PULL_SECRET` with the value of the Red hat Marketplace Pull Secret.
     ```sh
@@ -87,12 +76,12 @@ The operator releases adhere to semantic versioning and provides a seamless upgr
     ```
     oc patch marketplaceconfig marketplaceconfig -n redhat-marketplace --type='merge' -p '{"spec": {"license": {"accept": true}}}'
     ```
-6. Install the Red Hat Marketplace pull secret as a global pull secret on the cluster.
+6. Install the pull secret as a global pull secret on the cluster.
 
     These steps require `oc`, `jq`, and `base64` to be available on your machine.
 
     ```sh
-    # Create the docker pull secret file using your PULL_SECRET from Red Hat Marketplace.
+    # Create the docker pull secret file using your PULL_SECRET from IBM Software Central.
     # Store it in a file called entitledregistryconfigjson.
     oc create secret docker-registry entitled-registry --docker-server=registry.marketplace.redhat.com --docker-username "cp" --docker-password "${PULL_SECRET}" --dry-run=client --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode > entitledregistryconfigjson
     # Get the current global secrets on the cluster and store it as a file named dockerconfigjson
@@ -104,7 +93,7 @@ The operator releases adhere to semantic versioning and provides a seamless upgr
     ```
 
 ### Why is a global pull secret required?
-In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approaches, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
+In order to successfully install the products hosted by the container image registry, you will need to make the pull secret available across the cluster. This can be achieved by applying the pull as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approaches, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
 
 ### Subscription Config
 
@@ -140,12 +129,12 @@ A limitation is that the `config` elements are only appended to the operands. Th
 
 
 ### Documentation
-You can find our documentation [here.](https://marketplace.redhat.com/en-us/documentation/)
+You can find our documentation [here.](https://swc.saas.ibm.com/en-us/documentation/)
 
 ### Getting help
 If you encounter any issues while using Red Hat Marketplace operator, you can create an issue on our [Github
 repo](https://github.com/redhat-marketplace/redhat-marketplace-operator) for bugs, enhancements, or other requests. You can also visit our main page and
-review our [support](https://marketplace.redhat.com/en-us/support) and [documentation](https://marketplace.redhat.com/en-us/documentation/).
+review our [support](https://swc.saas.ibm.com/en-us/support) and [documentation](https://swc.saas.ibm.com/en-us/documentation/).
 
 ### Readme
 You can find our readme [here.](https://github.com/redhat-marketplace/redhat-marketplace-operator/blob/develop/README.md)

--- a/reporter/v2/pkg/reporter/uploader.go
+++ b/reporter/v2/pkg/reporter/uploader.go
@@ -145,8 +145,8 @@ func provideCOSS3Config(
 }
 
 const (
-	MktplProductionURL = "https://marketplace.redhat.com"
-	MktplStageURL      = "https://sandbox.marketplace.redhat.com"
+	MktplProductionURL = "https://swc.saas.ibm.com"
+	MktplStageURL      = "https://sandbox.swc.saas.ibm.com"
 )
 
 func provideMarketplaceConfig(

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,8 +1,10 @@
-The IBM Metrics Operator provides workload metering and reporting for IBM Software Central customers.
+The IBM Metrics Operator provides workload metering and reporting for IBM Software Central and Red Hat Marketplace customers.
 ### **Important Note**
 A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [swc.saas.ibm.com](https://swc.saas.ibm.com).
 
-Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+Usage metrics may be monitored through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) with only IBM Metrics Operator and a Red Hat Marketplace account, and does not require Red Hat Marketplace Deployment Operator.
+
+Full cluster registration and software lifecycle management through [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -144,14 +146,14 @@ spec:
 ```
 
 ### Installation
-1. Create or get your pull secret from [IBM Software Central](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
+1. Create or get your [pull secret](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
 2. Install the IBM Metrics Operator
 3. Create a Kubernetes secret in the installed namespace with the name `redhat-marketplace-pull-secret` and key `PULL_SECRET` with the value of the pull secret.
     ```sh
-    # Replace ${PULL_SECRET} with your secret from IBM Software Central
-    oc create secret generic redhat-marketplace-pull-secret -n  redhat-marketplace --from-literal=PULL_SECRET=${PULL_SECRET}
+    # Replace ${PULL_SECRET} with your pull secret
+    oc create secret generic redhat-marketplace-pull-secret -n redhat-marketplace --from-literal=PULL_SECRET=${PULL_SECRET}
     ```
-4. Use of the IBM Software Central platform is governed by the:
+4. Use of the platform is governed by the:
 
     [IBM Cloud Services Agreement](https://www.ibm.com/support/customer/csol/terms/?id=Z126-6304_WS&_ga=2.116312197.2046730452.1684328846-812467790.1684328846) (or other base agreement between you and IBM such as a [Passport Advantage Agreement](https://www.ibm.com/software/passportadvantage/pa_agreements.html?_ga=2.116312197.2046730452.1684328846-812467790.1684328846)) and the [Service Description for the Red Hat Marketplace](https://www.ibm.com/support/customer/csol/terms/?id=i126-8719&_ga=2.83289621.2046730452.1684328846-812467790.1684328846).
     
@@ -164,7 +166,7 @@ spec:
     These steps require `oc`, `jq`, and `base64` to be available on your machine.
 
     ```sh
-    # Create the docker pull secret file using your PULL_SECRET from IBM Software Central.
+    # Create the docker pull secret file using your pull secret.
     # Store it in a file called entitledregistryconfigjson.
     oc create secret docker-registry entitled-registry --docker-server=registry.marketplace.redhat.com --docker-username "cp" --docker-password "${PULL_SECRET}" --dry-run=client --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode > entitledregistryconfigjson
     # Get the current global secrets on the cluster and store it as a file named dockerconfigjson
@@ -248,7 +250,7 @@ A limitation is that the `config` elements are only appended to the operands. Th
 You can find our documentation [here.](https://swc.saas.ibm.com/en-us/documentation/)
 
 ### Getting help
-If you encounter any issues while using Red Hat Marketplace operator, you can create an issue on our [Github
+If you encounter any issues while using the operators, you can create an issue on our [Github
 repo](https://github.com/redhat-marketplace/redhat-marketplace-operator) for bugs, enhancements, or other requests. You can also visit our main page and
 review our [support](https://swc.saas.ibm.com/en-us/support) and [documentation](https://swc.saas.ibm.com/en-us/documentation/).
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,19 +1,8 @@
-The IBM Metrics Operator provides workload metering and reporting for IBM and Red Hat Marketplace customers.
+The IBM Metrics Operator provides workload metering and reporting for IBM Software Central customers.
 ### **Important Note**
-A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [marketplace.redhat.com](https://marketplace.redhat.com).
+A set of instructions for onboarding is provided here. For more detailed onboarding instructions or information about what is installed please visit [swc.saas.ibm.com](https://swc.saas.ibm.com).
 
-### **Upgrade Notice**
-
-The Red Hat Marketplace Operator metering and deployment functionalities have been separated into two operators.
-  - The metering functionality is included in this IBM Metrics Operator
-    - Admin level functionality and permissions are removed from the IBM Metrics Operator
-    - ClusterServiceVersion/ibm-metrics-operator
-  - The deployment functionality remains as part of the Red Hat Marketplace Deployment Operator by IBM
-    - The Red Hat Marketplace Deployment Operator prerequisites the IBM Metrics Operator
-    - Some admin level RBAC permissions are required for deployment functionality
-    - ClusterServiceVersion/redhat-marketplace-operator
-
-Full registration and visibility of usage metrics on [https://marketplace.redhat.com](https://marketplace.redhat.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
+Full registration and visibility of usage metrics on [https://swc.saas.ibm.com](https://swc.saas.ibm.com) requires both IBM Metrics Operator and Red Hat Marketplace Deployment Operator.
 
 ### Upgrade Policy
 
@@ -79,7 +68,7 @@ Minimum system resources required:
 | --------- | ----------- | ----------- | --------- | ----- |
 | **[Openshift User Workload Monitoring](https://docs.openshift.com/container-platform/latest/monitoring/enabling-monitoring-for-user-defined-projects.html)** |          1  |     0.1       | 2x40        |   2    |
 
-Multiple nodes are required to provide pod scheduling for high availability for Red Hat Marketplace Data Service and Prometheus.
+Multiple nodes are required to provide pod scheduling for high availability for IBM Metrics Operator Data Service and Prometheus.
 
 The IBM Metrics Operator automatically creates 3 x 1Gi PersistentVolumeClaims to store reports as part of the data service, with _ReadWriteOnce_ access mode. Te PersistentVolumeClaims are automatically created by the ibm-metrics-operator after creating a `redhat-marketplace-pull-secret` and accepting the license in `marketplaceconfig`.
 
@@ -155,14 +144,14 @@ spec:
 ```
 
 ### Installation
-1. Create or get your pull secret from [Red Hat Marketplace](https://marketplace.redhat.com/en-us/documentation/clusters#get-pull-secret).
+1. Create or get your pull secret from [IBM Software Central](https://swc.saas.ibm.com/en-us/documentation/clusters#get-pull-secret).
 2. Install the IBM Metrics Operator
-3. Create a Kubernetes secret in the installed namespace with the name `redhat-marketplace-pull-secret` and key `PULL_SECRET` with the value of the Red hat Marketplace Pull Secret.
+3. Create a Kubernetes secret in the installed namespace with the name `redhat-marketplace-pull-secret` and key `PULL_SECRET` with the value of the pull secret.
     ```sh
-    # Replace ${PULL_SECRET} with your secret from Red Hat Marketplace
+    # Replace ${PULL_SECRET} with your secret from IBM Software Central
     oc create secret generic redhat-marketplace-pull-secret -n  redhat-marketplace --from-literal=PULL_SECRET=${PULL_SECRET}
     ```
-4. Use of the Red Hat Marketplace platform is governed by the:
+4. Use of the IBM Software Central platform is governed by the:
 
     [IBM Cloud Services Agreement](https://www.ibm.com/support/customer/csol/terms/?id=Z126-6304_WS&_ga=2.116312197.2046730452.1684328846-812467790.1684328846) (or other base agreement between you and IBM such as a [Passport Advantage Agreement](https://www.ibm.com/software/passportadvantage/pa_agreements.html?_ga=2.116312197.2046730452.1684328846-812467790.1684328846)) and the [Service Description for the Red Hat Marketplace](https://www.ibm.com/support/customer/csol/terms/?id=i126-8719&_ga=2.83289621.2046730452.1684328846-812467790.1684328846).
     
@@ -170,12 +159,12 @@ spec:
     ```
     oc patch marketplaceconfig marketplaceconfig -n redhat-marketplace --type='merge' -p '{"spec": {"license": {"accept": true}}}'
     ```
-6. Install the Red Hat Marketplace pull secret as a global pull secret on the cluster.
+6. Install the pull secret as a global pull secret on the cluster.
 
     These steps require `oc`, `jq`, and `base64` to be available on your machine.
 
     ```sh
-    # Create the docker pull secret file using your PULL_SECRET from Red Hat Marketplace.
+    # Create the docker pull secret file using your PULL_SECRET from IBM Software Central.
     # Store it in a file called entitledregistryconfigjson.
     oc create secret docker-registry entitled-registry --docker-server=registry.marketplace.redhat.com --docker-username "cp" --docker-password "${PULL_SECRET}" --dry-run=client --output="jsonpath={.data.\.dockerconfigjson}" | base64 --decode > entitledregistryconfigjson
     # Get the current global secrets on the cluster and store it as a file named dockerconfigjson
@@ -187,7 +176,7 @@ spec:
     ```
 
 ### Why is a global pull secret required?
-In order to successfully install the Red Hat Marketplace products, you will need to make the pull secret available across the cluster. This can be achieved by applying the Red Hat Marketplace Pull Secret as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approaches, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
+In order to successfully install the products hosted by the container image registry, you will need to make the pull secret available across the cluster. This can be achieved by applying the pull as a [global pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets). For alternative approaches, please see the official OpenShift [documentation](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html).
 
 
 ### SecurityContextConstraints requirements
@@ -256,12 +245,12 @@ A limitation is that the `config` elements are only appended to the operands. Th
 
 
 ### Documentation
-You can find our documentation [here.](https://marketplace.redhat.com/en-us/documentation/)
+You can find our documentation [here.](https://swc.saas.ibm.com/en-us/documentation/)
 
 ### Getting help
 If you encounter any issues while using Red Hat Marketplace operator, you can create an issue on our [Github
 repo](https://github.com/redhat-marketplace/redhat-marketplace-operator) for bugs, enhancements, or other requests. You can also visit our main page and
-review our [support](https://marketplace.redhat.com/en-us/support) and [documentation](https://marketplace.redhat.com/en-us/documentation/).
+review our [support](https://swc.saas.ibm.com/en-us/support) and [documentation](https://swc.saas.ibm.com/en-us/documentation/).
 
 ### Readme
 You can find our readme [here.](https://github.com/redhat-marketplace/redhat-marketplace-operator/blob/develop/README.md)

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -68,8 +68,8 @@ const (
 	RELATED_IMAGE_PROM_SERVER      = "RELATED_IMAGE_PROM_SERVER"
 	RELATED_IMAGE_CONFIGMAP_RELOAD = "RELATED_IMAGE_CONFIGMAP_RELOAD"
 
-	PROM_DEP_NEW_WARNING_MSG     = "Use of redhat-marketplace-operator Prometheus is deprecated. Configuration of user workload monitoring is required https://marketplace.redhat.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
-	PROM_DEP_UPGRADE_WARNING_MSG = "Use of redhat-marketplace-operator Prometheus is deprecated, and will be removed next release. Configure user workload monitoring https://marketplace.redhat.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
+	PROM_DEP_NEW_WARNING_MSG     = "Use of redhat-marketplace-operator Prometheus is deprecated. Configuration of user workload monitoring is required https://swc.saas.ibm.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
+	PROM_DEP_UPGRADE_WARNING_MSG = "Use of redhat-marketplace-operator Prometheus is deprecated, and will be removed next release. Configure user workload monitoring https://swc.saas.ibm.com/en-us/documentation/red-hat-marketplace-operator#integration-with-openshift-container-platform-monitoring"
 )
 
 var (

--- a/v2/pkg/utils/env.go
+++ b/v2/pkg/utils/env.go
@@ -134,8 +134,8 @@ const (
 
 	DeploymentConfigName = "rhm-meterdefinition-file-server"
 	FileServerAudience   = "rhm-meterdefinition-file-server.openshift-redhat-marketplace.svc"
-	ProductionURL        = "https://marketplace.redhat.com"
-	StageURL             = "https://sandbox.marketplace.redhat.com"
+	ProductionURL        = "https://swc.saas.ibm.com"
+	StageURL             = "https://sandbox.swc.saas.ibm.com"
 
 	ProdEnv  = "production"
 	StageEnv = "stage"


### PR DESCRIPTION
- Update code comm endpoints to new swc.saas.ibm.com domain
- Update documentation links to swc.saas.ibm.com domain
- Indicate this is for SWC & RHM customers
- Debrand from specific SWC or RHM terms where possible, favoring SWC if necessary


Checklist

- [ ] links are correct
- [ ] grammar / verbage is correct
- [ ] technical details are accurate


TBD
- registry