### PR TITLE
fix: proxy v4.15, rrs3 relatedImage, imagepullpolicy

### DIFF
--- a/utils.Makefile
+++ b/utils.Makefile
@@ -21,7 +21,7 @@ DOCKER_BUILD := docker build
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 DOCKERBUILDXCACHE ?=
 
-KUBE_RBAC_PROXY_IMAGE ?= registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
+KUBE_RBAC_PROXY_IMAGE ?= registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15
 
 clean-bin:
 	rm -rf $(PROJECT_DIR)/bin

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -137,7 +137,7 @@ spec:
             - --tls-private-key-file=/etc/tls/private/tls.key
             - --auth-token-audiences=rhm-data-service,rhm-data-service.{{NAMESPACE}}.svc
           image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy-1
           ports:
             - containerPort: 8004
@@ -184,7 +184,7 @@ spec:
             - --tls-private-key-file=/etc/tls/private/tls.key
             - --auth-token-audiences=rhm-data-service,rhm-data-service.{{NAMESPACE}}.svc
           image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy-2
           ports:
             - containerPort: 8008

--- a/v2/assets/razee/remote-resource-s3.yaml
+++ b/v2/assets/razee/remote-resource-s3.yaml
@@ -74,7 +74,7 @@ spec:
                   name: razeedeploy-overrides
                   key: CRD_WATCH_TIMEOUT_SECONDS
                   optional: true
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: remoteresource-controller
           livenessProbe:
             exec:

--- a/v2/assets/razee/watch-keeper.yaml
+++ b/v2/assets/razee/watch-keeper.yaml
@@ -51,7 +51,7 @@ spec:
           - name: NODE_ENV
             value: "production"
         image: "us.icr.io/armada-master/watch-keeper:0.8.10_7f655fe"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: watch-keeper
         resources:
           limits:

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
           containers:
           - name: reporter
             image: redhat-markplace-reporter
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             # additional args are added in factory
             args:
               - 'reconcile'

--- a/v2/assets/reporter/user-workload-monitoring-job.yaml
+++ b/v2/assets/reporter/user-workload-monitoring-job.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
         - name: reporter
           image: redhat-markplace-reporter
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           # additional args are added in factory
           args:
             [

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -78,7 +78,7 @@ type RelatedImages struct {
 	MetricState        string `env:"RELATED_IMAGE_METRIC_STATE" envDefault:"metric-state:latest"`
 	AuthChecker        string `env:"RELATED_IMAGE_AUTHCHECK" envDefault:"authcheck:latest"`
 	DQLite             string `env:"RELATED_IMAGE_DQLITE" envDefault:"dqlite:latest"`
-	RemoteResource     string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.19_7f655fe"`
+	RemoteResource     string `env:"RELATED_IMAGE_RHM_RRS3_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.19_7f655fe"`
 	WatchKeeper        string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.10_7f655fe"`
 	MeterDefFileServer string `env:"RELATED_IMAGE_METERDEF_FILE_SERVER" envDefault:"quay.io/rh-marketplace/rhm-meterdefinition-file-server:v1"`
 }
@@ -90,7 +90,7 @@ type OSRelatedImages struct {
 	MetricState        string `env:"RELATED_IMAGE_METRIC_STATE" envDefault:"metric-state:latest"`
 	AuthChecker        string `env:"RELATED_IMAGE_AUTHCHECK" envDefault:"authcheck:latest"`
 	DQLite             string `env:"RELATED_IMAGE_DQLITE" envDefault:"dqlite:latest"`
-	RemoteResource     string `env:"RELATED_IMAGE_RHM_RRS_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.19_7f655fe"`
+	RemoteResource     string `env:"RELATED_IMAGE_RHM_RRS3_DEPLOYMENT" envDefault:"us.icr.io/armada-master/remoteresource:2.1.19_7f655fe"`
 	WatchKeeper        string `env:"RELATED_IMAGE_RHM_WATCH_KEEPER_DEPLOYMENT" envDefault:"us.icr.io/armada-master/watch-keeper:0.8.10_7f655fe"`
 	MeterDefFileServer string `env:"RELATED_IMAGE_METERDEF_FILE_SERVER" envDefault:"quay.io/rh-marketplace/rhm-meterdefinition-file-server:v1"`
 }


### PR DESCRIPTION
- images by digest should be set to imagePullPolicy: IfNotPresent
- update kube-rbac-proxy to v4.15
- fix the mismatched rrs3 deployment name not passing the digest image from env var