### PR TITLE
fix: reduce cache footprint of csvs

### DIFF
--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -106,7 +106,7 @@ func (r *MeterBaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			{
 				NamespacedName: types.NamespacedName{
 					Name:      "rhm-marketplaceconfig-meterbase",
-					Namespace: a.GetNamespace(),
+					Namespace: r.Cfg.DeployedNamespace,
 				},
 			},
 		}


### PR DESCRIPTION
- metric-state
  - switch the CSV get to PartialObjectMetadata, which causes a use of the metadataclient
  - The standard client full CSV Get will cause a ListWatch to start, and cache all CSVs on the cluster, which leads to high memory usage
  - change the installedByNamespace func to receive a generic client Object interface, and read the metadata of the csv PartialObjectMetadata
  
ibm-metrics-operator
  - switch the byobject field selector to namespaces scope, introduced in controller-runtime v0.16, should be a more efficient ListWatch
  - scope the statefulset cache to just pod namespace and user-workload-monitoring namespace, as we check for prometheus state
  - set the clusterserviceversion cache to just objects that are not copies, via labelselector, trim the Spec, we only need the metadata
    - unlike metric-state, we still need to be informed about all ClusterServiceVersions to reconcile, but we need to cache very little
  - fix the namespace of the meterbase map function, the namespace should always be the deployed namespace the local meterbase object, not the namespace of an object that triggered the reconciler