### PR TITLE
fix: replace jwt to satisfy depbot

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -193,6 +193,7 @@ require (
 )
 
 replace (
+	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/banzaicloud/k8s-objectmatcher => github.com/banzaicloud/k8s-objectmatcher v1.6.1
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock => github.com/golang/mock v1.4.4


### PR DESCRIPTION
Dependabot is firing alerts for v2/go.mod, even though dgrijalva is neither in any go.mod or go.sum
https://github.com/redhat-marketplace/redhat-marketplace-operator/security/dependabot/219