### PR TITLE
Bugfix/cmo

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Attempting to meter a resource with a MeterDefinition without the required permi
 
 To plan for disaster recovery, note the PhysicalVolumeClaims `rhm-data-service-rhm-data-service-N`. 
 - In connected environments, MeterReport data upload attempts occur hourly, and are then removed from data-service. There is a low risk of losing much unreported data.
-- In an airgap environment, MeterReport data must be pulled from data-service and uploaded manually using `datactl`. To prevent data loss in a disaster scenario, the data-service volumes should be considered in a recovery plan.
+- In an airgap environment, MeterReport data must be pulled from data-service and uploaded manually using [datactl](https://github.com/redhat-marketplace/datactl/). To prevent data loss in a disaster scenario, the data-service volumes should be considered in a recovery plan.
 
 ### Subscription Config
 

--- a/airgap/v2/buf.lock
+++ b/airgap/v2/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: 2bbd25900cb34c79bae97d85c948d3cf
-    digest: shake256:a6446e23f4408160217c22738a0c8c370ff3ff966f601d678960b803829cf53b5cf5998d20fcb3f9c9be944b24337843e7beb6e681ddbf9d036fb6491c0e47e7
+    commit: 8bc2c51e08c447cd8886cdea48a73e14
+    digest: shake256:a969155953a5cedc5b2df5b42c368f2bc66ff8ce1804bc96e0f14ff2ee8a893687963058909df844d1643cdbc98ff099d2daa6bc9f9f5b8886c49afdc60e19af
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway

--- a/v2/README.md
+++ b/v2/README.md
@@ -215,7 +215,7 @@ Attempting to meter a resource with a MeterDefinition without the required permi
 
 To plan for disaster recovery, note the PhysicalVolumeClaims `rhm-data-service-rhm-data-service-N`. 
 - In connected environments, MeterReport data upload attempts occur hourly, and are then removed from data-service. There is a low risk of losing much unreported data.
-- In an airgap environment, MeterReport data must be pulled from data-service and uploaded manually using `datactl`. To prevent data loss in a disaster scenario, the data-service volumes should be considered in a recovery plan.
+- In an airgap environment, MeterReport data must be pulled from data-service and uploaded manually using [datactl](https://github.com/redhat-marketplace/datactl/). To prevent data loss in a disaster scenario, the data-service volumes should be considered in a recovery plan.
 
 ### Subscription Config
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -52,7 +52,7 @@ require (
 	dario.cat/mergo v1.0.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/golang-jwt/jwt/v5 v5.2.0
-	github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240417033437-1839fb4d246a
+	github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240730115643-427c9f20c934
 	github.com/operator-framework/operator-lifecycle-manager v0.22.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.66.0
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -598,8 +598,8 @@ github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799 h1:rc3
 github.com/opencontainers/image-spec v1.0.3-0.20211202183452-c5a74bcca799/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/openshift/api v0.0.0-20240304080513-3e8192a10b13 h1:KNaEkpcVi4XGb86cA6FMJ8Wia7KWAembCUv8blIksTY=
 github.com/openshift/api v0.0.0-20240304080513-3e8192a10b13/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
-github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240417033437-1839fb4d246a h1:xwmkEnl8LaDQBZCirOQdroUI+PPvTgZG6/CcvWCDIgw=
-github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240417033437-1839fb4d246a/go.mod h1:k420O2JH7kTX/b8+KsC++Ad/pq7YY1KZwIMS+w7r8r0=
+github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240730115643-427c9f20c934 h1:wUsRJkKypMBY3h1r7p1X/akMmOW9XsyUcSg/inX3UVU=
+github.com/openshift/cluster-monitoring-operator v0.1.1-0.20240730115643-427c9f20c934/go.mod h1:k420O2JH7kTX/b8+KsC++Ad/pq7YY1KZwIMS+w7r8r0=
 github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb h1:ru6U+KzNbVFZXSfUkuH6WfHGCZ8rpBvKkJo8nXF+n5k=
 github.com/openshift/library-go v0.0.0-20230120214501-9bc305884fcb/go.mod h1:wrrjvk/CK+nte9Wxend9/K6apy6Zep28lzM27/aJar8=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2024-1139

is reported by quay scanner, though the current level used should have the fix update
we are not at risk as we only import to decode the userworkloadmonitoring struct
updating to see if it satisfies the scanner, but it doesn't

update datactl in the readme to a hyperlink