### PR TITLE
win nfs compat, wTx retry

### DIFF
--- a/airgap/v2/go.mod
+++ b/airgap/v2/go.mod
@@ -36,6 +36,8 @@ require (
 
 require (
 	github.com/Rican7/retry v0.3.0 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
+	github.com/avast/retry-go/v4 v4.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/airgap/v2/go.sum
+++ b/airgap/v2/go.sum
@@ -50,6 +50,10 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=

--- a/airgap/v2/pkg/database/filestore.go
+++ b/airgap/v2/pkg/database/filestore.go
@@ -22,12 +22,11 @@ import (
 	"time"
 
 	"emperror.dev/errors"
-	"github.com/go-logr/logr"
+	retry "github.com/avast/retry-go/v4"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/apis/dataservice/v1/fileserver"
 	modelsv2 "github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2/pkg/models/v2"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type StoredFileStore interface {
@@ -43,7 +42,6 @@ type StoredFileStore interface {
 func New(db *gorm.DB, config FileStoreConfig) (StoredFileStore, io.Closer) {
 	store := &fileStore{
 		DB:     db,
-		Log:    logf.Log.WithName("file_store"),
 		config: config,
 	}
 	return store, store
@@ -55,7 +53,6 @@ type FileStoreConfig struct {
 
 type fileStore struct {
 	*gorm.DB
-	Log logr.Logger
 
 	config FileStoreConfig
 }
@@ -77,14 +74,15 @@ type metaDataQuery struct {
 }
 
 const (
-	ErrInvalidInput = errors.Sentinel("invalid input")
-	ErrNotFound     = errors.Sentinel("not found")
+	ErrInvalidInput     = errors.Sentinel("invalid input")
+	ErrNotFound         = errors.Sentinel("not found")
+	ErrDatabaseIsLocked = errors.Sentinel("database is locked")
 )
 
 func (d *fileStore) Close() error {
 	sqlDB, err := d.DB.DB()
 	if err != nil {
-		d.Log.Error(err, "couldn't close db")
+		d.Logger.Error(context.TODO(), fmt.Sprintf("couldn't close db %v", err))
 		return err
 	}
 	return sqlDB.Close()
@@ -172,10 +170,35 @@ func (d *fileStore) Save(ctx context.Context, file *modelsv2.StoredFile) (string
 		}
 	}
 
+	deadline, ok := ctx.Deadline()
+
+	d.Logger.Info(ctx, fmt.Sprintf("Save Create() %v %v", deadline, ok))
+
 	//notFound create it
 	if foundFile == nil || foundFile.ID == 0 {
-		err := d.DB.WithContext(ctx).
-			Create(file).Error
+
+		err := d.retryWriteTx(ctx, func() *gorm.DB {
+			return d.DB.WithContext(ctx).Create(file)
+		}).Error
+
+		/*
+			delay, _ := time.ParseDuration("50ms")
+			err := retry.Do(
+				func() error {
+					return d.DB.WithContext(ctx).Create(file).Error
+				},
+				retry.RetryIf(func(err error) bool {
+					d.Logger.Info(ctx, fmt.Sprintf("Database is locked, retry %v %v", deadline, ok))
+					return err == ErrDatabaseIsLocked
+				}),
+				retry.Context(ctx),
+				retry.Attempts(0),
+				retry.Delay(delay),
+				retry.MaxJitter(delay),
+				retry.DelayType(retry.CombineDelay(retry.RandomDelay, retry.BackOffDelay)),
+			)
+		*/
+
 		return fmt.Sprintf("%d", file.ID), err
 	}
 
@@ -199,13 +222,20 @@ func (d *fileStore) Save(ctx context.Context, file *modelsv2.StoredFile) (string
 		}
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			metadata.FileID = foundFile.ID
-			err := db.Create(metadata).Error
+
+			err := d.retryWriteTx(ctx, func() *gorm.DB {
+				return db.Create(metadata)
+			}).Error
+
 			if err != nil {
 				err = errors.WithStack(err)
 				return "", err
 			}
 		} else {
-			err := db.Model(foundMetadata).Updates(metadata).Error
+			err := d.retryWriteTx(ctx, func() *gorm.DB {
+				return db.Model(foundMetadata).Updates(metadata)
+			}).Error
+
 			if err != nil {
 				err = errors.WithStack(err)
 				return "", err
@@ -217,8 +247,11 @@ func (d *fileStore) Save(ctx context.Context, file *modelsv2.StoredFile) (string
 	if len(content.Content) != 0 {
 		if content.ID != 0 {
 			foundContent := &foundFile.File
-			err := db.Model(foundContent).
-				Updates(content).Error
+
+			err := d.retryWriteTx(ctx, func() *gorm.DB {
+				return db.Model(foundContent).
+					Updates(content)
+			}).Error
 
 			if err != nil {
 				err = errors.WithStack(err)
@@ -226,7 +259,10 @@ func (d *fileStore) Save(ctx context.Context, file *modelsv2.StoredFile) (string
 			}
 		} else {
 			content.FileID = foundFile.ID
-			err := db.Create(content).Error
+
+			err := d.retryWriteTx(ctx, func() *gorm.DB {
+				return db.Create(content)
+			}).Error
 
 			if err != nil {
 				err = errors.WithStack(err)
@@ -235,11 +271,14 @@ func (d *fileStore) Save(ctx context.Context, file *modelsv2.StoredFile) (string
 		}
 	}
 
-	err := d.DB.WithContext(ctx).
-		Omit("Content").
-		Model(foundFile).
-		Where("id = ?", foundFile.ID).
-		Updates(*file).Error
+	err := d.retryWriteTx(ctx, func() *gorm.DB {
+		return d.DB.WithContext(ctx).
+			Omit("Content").
+			Model(foundFile).
+			Where("id = ?", foundFile.ID).
+			Updates(*file)
+	}).Error
+
 	id := fmt.Sprintf("%d", foundFile.ID)
 	return id, err
 }
@@ -257,8 +296,14 @@ func (d *fileStore) Delete(ctx context.Context, id string, permanent bool) (err 
 		return err
 	}
 
-	err = db.Model(&modelsv2.StoredFile{}).
-		Delete(&modelsv2.StoredFile{}, idInt).Error
+	deadline, ok := ctx.Deadline()
+
+	d.Logger.Info(ctx, fmt.Sprintf("Save Delete() %v %v", deadline, ok))
+
+	err = d.retryWriteTx(ctx, func() *gorm.DB {
+		return db.Model(&modelsv2.StoredFile{}).
+			Delete(&modelsv2.StoredFile{}, idInt)
+	}).Error
 
 	return err
 }
@@ -318,7 +363,7 @@ func (d *fileStore) CleanTombstones(ctx context.Context) (int64, error) {
 	now := time.Now()
 	now = now.Add(-d.config.CleanupAfter)
 
-	d.Log.Info("cleaning up all files older than", "now", now.String())
+	d.Logger.Info(ctx, fmt.Sprintf("cleaning up all files older than now %v", now.String()))
 
 	q := d.WithContext(ctx).
 		Unscoped().
@@ -328,22 +373,29 @@ func (d *fileStore) CleanTombstones(ctx context.Context) (int64, error) {
 
 	var rowsAffected int64
 	err := d.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&modelsv2.StoredFileContent{}).
-			Where("file_id in (?)", q).
-			Delete(&[]modelsv2.StoredFileContent{}).Error; err != nil {
+
+		if err := d.retryWriteTx(ctx, func() *gorm.DB {
+			return tx.Model(&modelsv2.StoredFileContent{}).
+				Where("file_id in (?)", q).
+				Delete(&[]modelsv2.StoredFileContent{})
+		}).Error; err != nil {
 			return err
 		}
 
-		if err := tx.Model(&modelsv2.StoredFileMetadata{}).
-			Where("file_id in (?)", q).
-			Delete(&[]modelsv2.StoredFileMetadata{}).Error; err != nil {
+		if err := d.retryWriteTx(ctx, func() *gorm.DB {
+			return tx.Model(&modelsv2.StoredFileMetadata{}).
+				Where("file_id in (?)", q).
+				Delete(&[]modelsv2.StoredFileMetadata{})
+		}).Error; err != nil {
 			return err
 		}
 
-		tx1 := tx.Unscoped().
-			Model(&modelsv2.StoredFile{}).
-			Where("id in (?)", q).
-			Delete(&[]modelsv2.StoredFile{})
+		tx1 := d.retryWriteTx(ctx, func() *gorm.DB {
+			return tx.Unscoped().
+				Model(&modelsv2.StoredFile{}).
+				Where("id in (?)", q).
+				Delete(&[]modelsv2.StoredFile{})
+		})
 		if err := tx1.Error; err != nil {
 			return err
 		}
@@ -357,4 +409,25 @@ func (d *fileStore) CleanTombstones(ctx context.Context) (int64, error) {
 	}
 
 	return rowsAffected, nil
+}
+
+func (d *fileStore) retryWriteTx(ctx context.Context, f func() *gorm.DB) (tx *gorm.DB) {
+
+	delay, _ := time.ParseDuration("50ms")
+	retry.Do(
+		func() error {
+			tx = f()
+			return tx.Error
+		},
+		retry.RetryIf(func(err error) bool {
+			d.Logger.Info(ctx, fmt.Sprintf("Database is locked, retry"))
+			return err == ErrDatabaseIsLocked
+		}),
+		retry.Context(ctx),
+		retry.Attempts(0),
+		retry.Delay(delay),
+		retry.MaxJitter(delay),
+		retry.DelayType(retry.CombineDelay(retry.RandomDelay, retry.BackOffDelay)),
+	)
+	return tx
 }

--- a/airgap/v2/pkg/dqlite/setup_linux.go
+++ b/airgap/v2/pkg/dqlite/setup_linux.go
@@ -102,8 +102,6 @@ func (dc *DatabaseConfig) initDqlite() error {
 		if rerr := os.Rename(oldPath, dc.Dir); rerr != nil {
 			return errors.Wrapf(err, "can't os.Rename %s to %s", oldPath, dc.Dir)
 		}
-	} else if err != nil && !os.IsNotExist(err) { // unexpected error
-		return errors.Wrapf(err, "can't os.Stat %s", oldPath)
 	}
 
 	if err := os.MkdirAll(dc.Dir, 0755); err != nil {

--- a/airgap/v2/pkg/dqlite/setup_linux.go
+++ b/airgap/v2/pkg/dqlite/setup_linux.go
@@ -90,10 +90,10 @@ func (dc *DatabaseConfig) initDqlite() error {
 
 	// New Path
 	// Sanitize for Windows NFS
-	re := regexp.MustCompile(`[/\\?%*:|"<>]`)
+	re := regexp.MustCompile(`[\\?%*:|"<>]`)
 	dc.Dir = filepath.Join(
 		string(re.ReplaceAll([]byte(dc.Dir), []byte("-"))),
-		string(re.ReplaceAll([]byte(dc.Url), []byte("-"))),
+		string(re.ReplaceAll([]byte(dc.Name), []byte("-"))),
 	)
 
 	// Check & migrate Old Base Path


### PR DESCRIPTION
- `sigs.k8s.io/controller-runtime/pkg/log` not initialized, use already available fileStore Logger
- Change data-service basepath from baseDir + URL (host:port) to baseDir + Name("airgap")
  - replace any invalid characters for Windows to allow Windows NFS storage host to work
- Wrap write/locking transactions with a retry for database is locked