### PR TITLE
feat: refactor SecretFetcher, controller marketplace calls

### DIFF
--- a/reporter/v2/pkg/reporter/uploader.go
+++ b/reporter/v2/pkg/reporter/uploader.go
@@ -164,26 +164,16 @@ func provideMarketplaceConfig(
 		return nil, err
 	}
 
-	log.Info("found secret", "secret name", si.Name)
-
-	jwtToken, err := b.ParseAndValidate(si)
-	if err != nil {
-		return nil, err
-	}
-
-	tokenClaims, err := marketplace.GetJWTTokenClaim(jwtToken)
-	if err != nil {
-		return nil, err
-	}
+	log.Info("found secret", "secret name", si.Secret.GetName())
 
 	url := MktplProductionURL
-	if tokenClaims.Env == marketplace.EnvStage {
+	if si.Env == marketplace.EnvStage {
 		url = MktplStageURL
 	}
 
 	return &uploaders.MarketplaceUploaderConfig{
 		URL:          url,
-		Token:        jwtToken,
+		Token:        si.Token,
 		CipherSuites: cipherSuites,
 		MinVersion:   minVersion,
 	}, nil

--- a/v2/controllers/marketplace/meterreport_creator_controller_test.go
+++ b/v2/controllers/marketplace/meterreport_creator_controller_test.go
@@ -160,7 +160,7 @@ var _ = Describe("MeterbaseController", func() {
 
 		AfterEach(func() {
 			// Add any teardown steps that needs to be executed after each test
-			Expect(k8sClient.Delete(context.TODO(), createdMeterBase)).Should(Succeed())
+			Cleanup()
 		})
 
 		It("should run meterbase creator reconciler", func() {

--- a/v2/controllers/marketplace/razeedeployment_controller_test.go
+++ b/v2/controllers/marketplace/razeedeployment_controller_test.go
@@ -24,7 +24,6 @@ import (
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -32,7 +31,6 @@ import (
 
 var _ = Describe("Testing with Ginkgo", func() {
 	var (
-		name            = utils.RAZEE_NAME
 		secretName      = utils.RHM_OPERATOR_SECRET_NAME
 		razeeDeployment marketplacev1alpha1.RazeeDeployment
 		secret          corev1.Secret
@@ -40,12 +38,11 @@ var _ = Describe("Testing with Ginkgo", func() {
 
 	BeforeEach(func() {
 
-		name = utils.RAZEE_NAME
 		secretName = utils.RHM_OPERATOR_SECRET_NAME
 
 		razeeDeployment = marketplacev1alpha1.RazeeDeployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
+				Name:      utils.RAZEE_NAME,
 				Namespace: operatorNamespace,
 				UID:       types.UID(uuid.NewUUID()),
 			},
@@ -94,56 +91,8 @@ var _ = Describe("Testing with Ginkgo", func() {
 	})
 
 	AfterEach(func() {
-		rd := &marketplacev1alpha1.RazeeDeployment{}
-		err := k8sClient.Get(context.TODO(), types.NamespacedName{
-			Name:      name,
-			Namespace: operatorNamespace,
-		}, rd)
-		if !k8serrors.IsNotFound(err) {
-			Expect(k8sClient.Delete(context.TODO(), rd)).Should(Succeed())
-		}
 
-		operatorSecret := &corev1.Secret{}
-		err = k8sClient.Get(context.TODO(), types.NamespacedName{
-			Name:      utils.RHM_OPERATOR_SECRET_NAME,
-			Namespace: operatorNamespace,
-		}, operatorSecret)
-		if !k8serrors.IsNotFound(err) {
-			Expect(k8sClient.Delete(context.TODO(), operatorSecret)).Should(Succeed())
-		}
-
-		marketplaceConfig := &marketplacev1alpha1.MarketplaceConfig{}
-		err = k8sClient.Get(context.TODO(), types.NamespacedName{
-			Name:      "marketplaceconfig",
-			Namespace: operatorNamespace,
-		}, marketplaceConfig)
-		if !k8serrors.IsNotFound(err) {
-			Expect(k8sClient.Delete(context.TODO(), marketplaceConfig)).Should(Succeed())
-		}
-
-		cmNames := []string{utils.WATCH_KEEPER_NON_NAMESPACED_NAME, utils.WATCH_KEEPER_LIMITPOLL_NAME, utils.WATCH_KEEPER_CONFIG_NAME, utils.RAZEE_CLUSTER_METADATA_NAME}
-		for _, name := range cmNames {
-			configMap := &corev1.ConfigMap{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{
-				Name:      name,
-				Namespace: operatorNamespace,
-			}, configMap)
-			if !k8serrors.IsNotFound(err) {
-				Expect(k8sClient.Delete(context.TODO(), configMap)).Should(Succeed())
-			}
-		}
-
-		secretNames := []string{utils.WATCH_KEEPER_SECRET_NAME, utils.RHM_OPERATOR_SECRET_NAME, utils.COS_READER_KEY_NAME}
-		for _, name := range secretNames {
-			secret := &corev1.Secret{}
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{
-				Name:      name,
-				Namespace: operatorNamespace,
-			}, secret)
-			if !k8serrors.IsNotFound(err) {
-				Expect(k8sClient.Delete(context.TODO(), secret)).Should(Succeed())
-			}
-		}
+		Cleanup()
 
 	})
 

--- a/v2/pkg/marketplace/marketplace_client.go
+++ b/v2/pkg/marketplace/marketplace_client.go
@@ -54,7 +54,7 @@ type MarketplaceClientConfig struct {
 	Url      string
 	Token    string
 	Insecure bool
-	Claims   *MarketplaceClaims
+	Claims   *utils.MarketplaceClaims
 }
 
 type MarketplaceClientAccount struct {
@@ -107,7 +107,7 @@ func NewMarketplaceClientBuilder(cfg *config.OperatorConfig) *MarketplaceClientB
 
 func (b *MarketplaceClientBuilder) NewMarketplaceClient(
 	token string,
-	tokenClaims *MarketplaceClaims,
+	tokenClaims *utils.MarketplaceClaims,
 ) (*MarketplaceClient, error) {
 	var tlsConfig *tls.Config
 	marketplaceURL := b.Url
@@ -381,21 +381,13 @@ func (mhttp *MarketplaceClient) GetMarketplaceSecret() (*corev1.Secret, error) {
 	return &newOptSecretObj, nil
 }
 
-type MarketplaceClaims struct {
-	AccountID string `json:"rhmAccountId"`
-	Password  string `json:"password,omitempty"`
-	APIKey    string `json:"iam_apikey,omitempty"`
-	Env       string `json:"env,omitempty"`
-	jwt.RegisteredClaims
-}
-
 const EnvStage = "stage"
 
 // GetJWTTokenClaims will parse JWT token and fetch the rhmAccountId
-func GetJWTTokenClaim(jwtToken string) (*MarketplaceClaims, error) {
+func GetJWTTokenClaim(jwtToken string) (*utils.MarketplaceClaims, error) {
 	// TODO: add verification of public key
 	parser := new(jwt.Parser)
-	token, parts, err := parser.ParseUnverified(jwtToken, &MarketplaceClaims{})
+	token, parts, err := parser.ParseUnverified(jwtToken, &utils.MarketplaceClaims{})
 
 	if err != nil {
 		return nil, err
@@ -411,7 +403,7 @@ func GetJWTTokenClaim(jwtToken string) (*MarketplaceClaims, error) {
 		return nil, err
 	}
 
-	claims, ok := token.Claims.(*MarketplaceClaims)
+	claims, ok := token.Claims.(*utils.MarketplaceClaims)
 
 	if !ok {
 		return nil, errors.New("token claims is not *MarketplaceClaims")

--- a/v2/pkg/marketplace/marketplace_client_test.go
+++ b/v2/pkg/marketplace/marketplace_client_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/config"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 )
 
 const timeout = time.Second * 100
@@ -92,7 +93,7 @@ var _ = Describe("Marketplace Config Status", func() {
 		}
 
 		token := "Bearer token"
-		tokenClaims := &MarketplaceClaims{
+		tokenClaims := &utils.MarketplaceClaims{
 			Env: "",
 		}
 


### PR DESCRIPTION
- Refactor utils SecretFetcherBuilder to parse, validate, and set token & claims. Update consumers
  - uploader
  - clusterregistration_controller
  - marketplaceconfig_controller
- Move MarketplaceClaims to utils. Update consumers
  - marketplace_client
  - secretfetcher
- secretutils
  - Handle decode validation, token and claims as part of SecretFetcherBuilder ReturnSecret
  - Reduce token validatation for controller logic flows
  - ibm-entitlement-key jwt written into secret/redhat-marketplace-pull-secret will be handled as type ibm-entitlement-key
    - warn in log; reduces unexpected behavior
- Remove account checking / marketplace calls from marketplaceconfig controller
- Handle cluster & account exists status in cluster registration controller, all marketplace calls
  - reduces reconciled calls to endpoint, simplies controller purpose & logic
- Update tests for controller changes