### PR TITLE
fix: remove fips-detect

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect
 COPY --from=builder /opt/app-root/src/go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 
 WORKDIR /usr/local/bin

--- a/authchecker/v2/Dockerfile
+++ b/authchecker/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -7,7 +7,6 @@ ENV PATH=$PATH:/opt/app-root/src/go/bin CGO_ENABLED=1
 ARG GRPC_HEALTH_VERSION=v0.4.25
 ARG DQLITE_VERSION=v1.16.7
 ARG LIBUV_VERSION=v1.48.0
-ARG FIPS_DETECT_VERSION=7157dae
 ARG quay_expiration=7d
 
 USER 0
@@ -29,5 +28,4 @@ RUN mkdir -p /opt/app-root/src/go/bin && \
     cd dqlite && autoreconf -i && ./configure --enable-build-raft --prefix=/usr --libdir=/usr/lib64 && make && make install && \
     cd .. && rm -Rf dqlite && \
     go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_VERSION} && \
-    go install github.com/acardace/fips-detect@${FIPS_DETECT_VERSION} && \
     go clean -modcache

--- a/datareporter/v2/Dockerfile
+++ b/datareporter/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/metering/v2/Dockerfile
+++ b/metering/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/reporter/v2/Dockerfile
+++ b/reporter/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -51,7 +51,6 @@ COPY v2/LICENSE v2/_licenses/* /licenses/
 RUN  /usr/local/bin/user_setup
 
 COPY --from=builder /opt/app-root/src/go/bin/${bin} /usr/local/bin/${bin}
-COPY --from=builder /opt/app-root/src/go/bin/fips-detect /usr/local/bin/fips-detect 
 
 WORKDIR /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/v2/hack/docker/bin/entrypoint
+++ b/v2/hack/docker/bin/entrypoint
@@ -11,7 +11,6 @@ if ! whoami &>/dev/null; then
 fi
 
 if [[ ! -v "$BINFILE" ]]; then
-    fips-detect $BINFILE
     exec $BINFILE $@
 fi
 


### PR DESCRIPTION
For UBI9, openssl v3, the GetSymbolPointer for `FIPS_mode` in fips-detect is no longer correct and leads to an error.

https://github.com/acardace/fips-detect/blob/main/pkg/fips/fips.go#L115

It may be that a Get for [EVP_default_properties_is_fips_enabled](https://docs.openssl.org/3.0/man3/EVP_set_default_properties/) would be a correct substitution
https://github.com/dacleyra/fips-detect/blob/main/pkg/fips/fips.go#L115

https://docs.openssl.org/3.0/man3/

In any case, at this point we have confidence we are building with openssl fips with the ubi go-toolset, so the tool is not necessary.