### PR TITLE
fix: secret delete race, deploymentreconciler predicate

### DIFF
--- a/v2/controllers/marketplace/clusterregistration_controller.go
+++ b/v2/controllers/marketplace/clusterregistration_controller.go
@@ -153,6 +153,11 @@ func (r *ClusterRegistrationReconciler) Reconcile(ctx context.Context, request r
 			return reconcile.Result{}, err
 		}
 
+		// Ensure Secrets have DeletionTimestamp, relying on GC is a race condition
+		if err := secretFetcher.DeleteSecret(); err != nil {
+			return reconcile.Result{}, nil
+		}
+
 		reqLogger.Info("marketplaceconfig delete is complete.")
 		return reconcile.Result{}, nil
 
@@ -505,7 +510,6 @@ func (r *ClusterRegistrationReconciler) SetupWithManager(mgr ctrl.Manager) error
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(e event.CreateEvent) bool { return true },
 				UpdateFunc: func(e event.UpdateEvent) bool {
-
 					marketplaceConfigNew, newOk := e.ObjectNew.(*marketplacev1alpha1.MarketplaceConfig)
 					marketplaceConfigOld, oldOk := e.ObjectOld.(*marketplacev1alpha1.MarketplaceConfig)
 

--- a/v2/controllers/marketplace/deployment_controller.go
+++ b/v2/controllers/marketplace/deployment_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/config"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/manifests"
 	utils "github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -50,6 +51,7 @@ type DeploymentReconciler struct {
 	Scheme  *runtime.Scheme
 	Log     logr.Logger
 	Factory *manifests.Factory
+	Cfg     *config.OperatorConfig
 }
 
 // +kubebuilder:rbac:groups="apps",namespace=system,resources=deployments,verbs=get;list;watch
@@ -117,7 +119,7 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{
 					Name:      utils.RHM_METERING_DEPLOYMENT_NAME,
-					Namespace: obj.GetNamespace(),
+					Namespace: r.Cfg.DeployedNamespace,
 				}},
 			}
 		})
@@ -139,13 +141,13 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 
 	pConfigMap := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+			return e.ObjectNew.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP && e.ObjectNew.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP && e.Object.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP
+			return e.Object.GetName() == utils.METRICS_OP_CA_BUNDLE_CONFIGMAP && e.Object.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
@@ -169,13 +171,13 @@ func (r *DeploymentReconciler) SetupWithManager(mgr manager.Manager) error {
 
 	pService := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetName() == utils.METRICS_OP_METRICS_SERVICE
+			return e.ObjectNew.GetName() == utils.METRICS_OP_METRICS_SERVICE && e.ObjectNew.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE && e.Object.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE
+			return e.Object.GetName() == utils.METRICS_OP_METRICS_SERVICE && e.Object.GetNamespace() == r.Cfg.DeployedNamespace
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false

--- a/v2/main.go
+++ b/v2/main.go
@@ -354,6 +354,7 @@ func main() {
 		Log:     ctrl.Log.WithName("controllers").WithName("DeploymentReconciler"),
 		Scheme:  mgr.GetScheme(),
 		Factory: factory,
+		Cfg:     opCfg,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DeploymentReconciler")
 		os.Exit(1)

--- a/v2/pkg/utils/secretutils.go
+++ b/v2/pkg/utils/secretutils.go
@@ -25,6 +25,7 @@ import (
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,6 +122,23 @@ func (sf *SecretFetcherBuilder) GetPullSecret() (*v1.Secret, error) {
 	}
 
 	return rhmPullSecret, nil
+}
+
+// Delete Secrets, ignore IsNotFound
+func (sf *SecretFetcherBuilder) DeleteSecret() error {
+	if err := sf.K8sClient.Delete(
+		sf.Ctx,
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: RHMPullSecretName, Namespace: sf.DeployedNamespace}},
+	); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	if err := sf.K8sClient.Delete(
+		sf.Ctx,
+		&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: IBMEntitlementKeySecretName, Namespace: sf.DeployedNamespace}},
+	); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }
 
 // Parse v1.Secret and return SecretInfo


### PR DESCRIPTION
- Explicitly delete pull secret on marketplaceconfig delete, as relying on garbage collection was a race condition. This could lead to marketplaceconfig being recreated by the reconciler.
- Correct the scope of the predicate to namespace for DeploymentReconciler. Because configmap and service kinds have cluster cache scope, a configmap or service with specific names could trigger reconciliation for the wrong namespace, leading to a "unknown namespace for the cache" error.