### PR TITLE
Bugfix/access checker

### DIFF
--- a/metering/v2/pkg/stores/dictionary.go
+++ b/metering/v2/pkg/stores/dictionary.go
@@ -91,12 +91,12 @@ func (def *MeterDefinitionDictionary) FindObjectMatches(
 
 		if err != nil {
 			if errors.Is(err, rhmclient.AccessDeniedErr) {
-				def.log.Info("skipping object", "error", err.Error())
+				def.log.Info("skipping object for resource filter", "error", err.Error())
 				continue
 			}
 
 			if !errors.Is(err, rhmclient.AccessDeniedErr) {
-				def.log.Error(err, "error finding matches")
+				def.log.Error(err, "error finding matches for resource filter")
 				return err
 			}
 

--- a/v2/pkg/client/access.go
+++ b/v2/pkg/client/access.go
@@ -61,7 +61,7 @@ func (a *AccessChecker) CheckAccess(gvr schema.GroupVersionResource) (bool, erro
 		}
 
 		if !review.Status.Allowed {
-			return false, fmt.Errorf("%w serviceaccount/%s does not have get/list/watch access to Resource: %s, Group: %s, Version: %s via clusterrole/view. Create a clusterrole with get/list/watch access and bind it to serviceaccount/%s, or create a clusterrole with get/list/watch access and add the annotation rbac.authorization.k8s.io/aggregate-to-view: 'true' to add access to clusterrole/view", AccessDeniedErr, utils.METRIC_STATE_SERVICE_ACCOUNT, gvr.Resource, gvr.Group, gvr.Version, utils.METRIC_STATE_SERVICE_ACCOUNT)
+			return false, fmt.Errorf("%w serviceaccount/%s does not have get/list/watch access to Resource: %s, Group: %s, Version: %s via clusterrole/view. If this resource type is necessary for your MeterDefinition resource filter, create a clusterrole with get/list/watch access and bind it to serviceaccount/%s, or create a clusterrole with get/list/watch access and add the annotation rbac.authorization.k8s.io/aggregate-to-view: 'true' to add access to clusterrole/view", AccessDeniedErr, utils.METRIC_STATE_SERVICE_ACCOUNT, gvr.Resource, gvr.Group, gvr.Version, utils.METRIC_STATE_SERVICE_ACCOUNT)
 		}
 	}
 

--- a/v2/pkg/client/access.go
+++ b/v2/pkg/client/access.go
@@ -22,6 +22,7 @@ import (
 	"github.com/redhat-marketplace/redhat-marketplace-operator/v2/pkg/utils"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
@@ -39,27 +40,29 @@ func NewAccessChecker(kubeClientSet clientset.Interface, ctx context.Context) Ac
 	}
 }
 
-func (a *AccessChecker) CheckAccess(group string, version string, kind string, namespace string) (bool, error) {
-	sar := &authv1.SubjectAccessReview{
-		Spec: authv1.SubjectAccessReviewSpec{
-			User: "system:serviceaccount:" + namespace + ":" + utils.METRIC_STATE_SERVICE_ACCOUNT,
-			ResourceAttributes: &authv1.ResourceAttributes{
-				Verb:     "list,watch",
-				Group:    group,
-				Resource: kind,
-				Version:  version,
+func (a *AccessChecker) CheckAccess(gvr schema.GroupVersionResource) (bool, error) {
+
+	reqAttrs := []authv1.ResourceAttributes{
+		{Resource: gvr.Resource, Group: gvr.Group, Version: gvr.Version, Verb: "list"},
+		{Resource: gvr.Resource, Group: gvr.Group, Version: gvr.Version, Verb: "get"},
+		{Resource: gvr.Resource, Group: gvr.Group, Version: gvr.Version, Verb: "watch"},
+	}
+
+	for _, reqAttr := range reqAttrs {
+		sar := &authv1.SelfSubjectAccessReview{
+			Spec: authv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &reqAttr,
 			},
-		},
-	}
+		}
 
-	opts := metav1.CreateOptions{}
-	review, err := a.kubeClient.AuthorizationV1().SubjectAccessReviews().Create(a.ctx, sar, opts)
-	if err != nil {
-		return false, err
-	}
+		review, err := a.kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(a.ctx, sar, metav1.CreateOptions{})
+		if err != nil {
+			return false, err
+		}
 
-	if !review.Status.Allowed {
-		return false, fmt.Errorf("%w serviceaccount/%s does not have get/list/watch access to Kind: %s, group: %s, version: %s via clusterrole/view. Create a clusterrole with get/list/watch access and bind it to serviceaccount/%s, or create a clusterrole with get/list/watch access and add the annotation rbac.authorization.k8s.io/aggregate-to-view: 'true' to add access to clusterrole/view", AccessDeniedErr, utils.METRIC_STATE_SERVICE_ACCOUNT, kind, group, version, utils.METRIC_STATE_SERVICE_ACCOUNT)
+		if !review.Status.Allowed {
+			return false, fmt.Errorf("%w serviceaccount/%s does not have get/list/watch access to Resource: %s, Group: %s, Version: %s via clusterrole/view. Create a clusterrole with get/list/watch access and bind it to serviceaccount/%s, or create a clusterrole with get/list/watch access and add the annotation rbac.authorization.k8s.io/aggregate-to-view: 'true' to add access to clusterrole/view", AccessDeniedErr, utils.METRIC_STATE_SERVICE_ACCOUNT, gvr.Resource, gvr.Group, gvr.Version, utils.METRIC_STATE_SERVICE_ACCOUNT)
+		}
 	}
 
 	return true, nil

--- a/v2/pkg/client/find_owner.go
+++ b/v2/pkg/client/find_owner.go
@@ -66,15 +66,14 @@ func (f *FindOwnerHelper) FindOwner(name, namespace string, lookupOwner *metav1.
 		version = apiVersionSplit[1]
 	}
 
-	_, err = f.accessChecker.CheckAccess(group, version, lookupOwner.Kind, namespace)
-	if err != nil {
-		return nil, err
-	}
-
 	mapping, err := f.client.restMapper.RESTMapping(schema.GroupKind{Group: group, Kind: lookupOwner.Kind}, version)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get mapping")
+	}
+
+	_, err = f.accessChecker.CheckAccess(mapping.Resource)
+	if err != nil {
+		return nil, err
 	}
 
 	informer := f.informers.GetInformer(*mapping)


### PR DESCRIPTION
The resource filter for ownerCRD has been broken for some time

A meterdefinition may define
```
resourceFilters:
- namespace:
	useOperatorGroup: true
  ownerCRD:
	apiVersion: my.group.com/v1alpha1
	kind: MyKind
  workloadType: Pod
```

The CheckAccess performed as part of FindOwner was using AccessReview incorrectly
- Verb is singular, and not a CSV
- The Resource should be the rest mapped Resource (Resource: `pods` not Kind: `Pod`)
- Can more conveniently use SelfSubjectAccessReview instead of SubjectAccessReview

This lead to 
- false AccessDeniedErr's
- no MeterDefinition status.workloadresource list being populated
- no results or metered match