### PR TITLE
fix: prevent NPE on GetFile err

### DIFF
--- a/reporter/v2/pkg/reporter/upload_task.go
+++ b/reporter/v2/pkg/reporter/upload_task.go
@@ -132,9 +132,10 @@ func (r *UploadTask) RunGeneric(ctx context.Context) error {
 				continue
 			}
 
+			fileId := file.Id
 			file, err = r.fileStorage.GetFile(ctx, file.Id)
 			if err != nil {
-				logger.Error(err, "failed to get file", "id", file.Id)
+				logger.Error(err, "failed to get file", "id", fileId)
 				continue
 			}
 


### PR DESCRIPTION
A failed GetFile() may return a nil file, don't use the file id from the return when logging the error