### PR TITLE
fix: go-toolset:1.22

### DIFF
--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
Update go-toolset for base images before package updates