### PR TITLE
fix: delay livenessprobe

### DIFF
--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
               command:
                 - grpc-health-probe
                 - -addr=localhost:8003
-            initialDelaySeconds: 60
+            initialDelaySeconds: 360
             periodSeconds: 5
           ports:
             - containerPort: 9001


### PR DESCRIPTION
Increase the livenessprobe delay to prevent a startup failure scenario

liveness probe success depends on reaching quroum
failed pod retry restart can increase restart time delay up to a max 300s
if this condition occurs, data-service pods will never start and pass liveness

This can be tested by scaling down the statefulset to 0, then to 1
Before the fix, once the pod has reached max restart delay of 300s, scale up to 3
Depending on timing, the pods may not be started in the same time window, resulting in persistent restarts from liveness probe failure