### PR TITLE
fix: homedir

### DIFF
--- a/airgap/v2/Dockerfile
+++ b/airgap/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin} \
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint

--- a/authchecker/v2/Dockerfile
+++ b/authchecker/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin}\
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint

--- a/datareporter/v2/Dockerfile
+++ b/datareporter/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin}\
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint

--- a/metering/v2/Dockerfile
+++ b/metering/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin} \
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint

--- a/metering/v2/cmd/main.go
+++ b/metering/v2/cmd/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2/pkg/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -91,7 +90,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := homedir.Dir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			er(err)
 		}

--- a/metering/v2/go.mod
+++ b/metering/v2/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/google/wire v0.5.0
 	github.com/gotidy/ptr v1.4.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/gomega v1.32.0
 	github.com/openshift/api v0.0.0-20240912201240-0a8800162826
 	github.com/operator-framework/api v0.18.0

--- a/metering/v2/go.sum
+++ b/metering/v2/go.sum
@@ -284,8 +284,6 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/reporter/v2/Dockerfile
+++ b/reporter/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin}\
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint

--- a/reporter/v2/cmd/reporter/main.go
+++ b/reporter/v2/cmd/reporter/main.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/cmd/reporter/reconciler"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/cmd/reporter/report"
 	"github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2/cmd/reporter/sign"
@@ -69,7 +68,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := homedir.Dir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			er(err)
 		}

--- a/reporter/v2/go.mod
+++ b/reporter/v2/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/google/wire v0.5.0
 	github.com/gotidy/ptr v1.4.0
 	github.com/meirf/gopart v0.0.0-20180520194036-37e9492a85a8
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/onsi/gomega v1.32.0
 	github.com/openshift/api v0.0.0-20240912201240-0a8800162826

--- a/reporter/v2/go.sum
+++ b/reporter/v2/go.sum
@@ -292,8 +292,6 @@ github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPk
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
-github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -42,7 +42,8 @@ LABEL name="Red Hat Marketplace ${name}" \
 
 ENV USER_UID=1001 \
   USER_NAME=redhat-marketplace-operator \
-  BINFILE=/usr/local/bin/${bin}
+  BINFILE=/usr/local/bin/${bin}\
+  HOME=/home/redhat-marketplace-operator
 
 # install operator binary
 COPY v2/hack/docker/bin/entrypoint /usr/local/bin/entrypoint


### PR DESCRIPTION
[script](https://github.com/redhat-marketplace/redhat-marketplace-operator/blob/develop/v2/hack/docker/bin/user_setup) was intended to setup home dir for user, but HOME was never set in Dockerfile

- runtime would previously set HOME default `/` 
- openshift 4.18 stopped setting a default HOME
- metric-state would exit due to home dir unresolvable during init
- use `os.UserHomeDir` instead of `github.com/mitchellh/go-homedir` since it no longer prevents cross compile