### PR TITLE
fix: nodes, consoles, clusterversion rbac for reporter

### DIFF
--- a/v2/config/rbac/reporter_cluster_role.yaml
+++ b/v2/config/rbac/reporter_cluster_role.yaml
@@ -17,6 +17,7 @@ rules:
     resources:
     - clusterversions
     - consoles
+    - infrastructures
     verbs:
     - get
     - list

--- a/v2/config/rbac/reporter_cluster_role.yaml
+++ b/v2/config/rbac/reporter_cluster_role.yaml
@@ -7,10 +7,20 @@ rules:
       - ''
     resources:
       - services
+      - nodes
     verbs:
       - get
       - watch
       - list
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - clusterversions
+    - consoles
+    verbs:
+    - get
+    - list
+    - watch
   - nonResourceURLs:
     - /api/v1/query
     - /api/v1/query_range

--- a/v2/controllers/marketplace/meterbase_controller.go
+++ b/v2/controllers/marketplace/meterbase_controller.go
@@ -570,26 +570,26 @@ func (r *MeterBaseReconciler) installMeterDefinitions(instance *marketplacev1alp
 		return err
 	}
 
-	msMeterDef, err := r.Factory.MetricStateMeterDefinition()
+	rMeterDef, err := r.Factory.ReporterMeterDefinition()
 	if err != nil {
 		return err
 	}
-	if err := r.Client.Delete(context.TODO(), msMeterDef); err != nil && !kerrors.IsNotFound(err) {
+	if err := r.Client.Delete(context.TODO(), rMeterDef); err != nil && !kerrors.IsNotFound(err) {
 		return err
 	}
 
 	cond := marketplaceConfig.Status.Conditions.GetCondition(marketplacev1alpha1.ConditionRHMAccountExists)
 	if cond == nil || cond.IsFalse() { // no account, do not report infrastructure
-		rMeterDef, err := r.Factory.ReporterMeterDefinition()
+		msMeterDef, err := r.Factory.MetricStateMeterDefinition()
 		if err != nil {
 			return err
 		}
-		if err := r.Client.Delete(context.TODO(), rMeterDef); err != nil && !kerrors.IsNotFound(err) {
+		if err := r.Client.Delete(context.TODO(), msMeterDef); err != nil && !kerrors.IsNotFound(err) {
 			return err
 		}
 	} else if cond.IsTrue() { // Create the Reporter MeterDefinition to report infrastructure
 		if err := r.Factory.CreateOrUpdate(r.Client, instance, func() (client.Object, error) {
-			return r.Factory.ReporterMeterDefinition()
+			return r.Factory.MetricStateMeterDefinition()
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
- reporter reads these resources for infrastructure reporting
- switch to metric-state meterdefinition to drive infrastructure reporting, reporter job query only produces results on failures