### PR TITLE
fix: update to go1.23

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -74,7 +74,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -100,7 +100,7 @@ jobs:
     name: Build Images
     runs-on: ubuntu-24.04
     env:
-      GO_VERSION: "1.22"
+      GO_VERSION: "1.23"
     defaults:
       run:
         shell: bash
@@ -112,7 +112,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
@@ -235,7 +235,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build Base
     runs-on: ubuntu-24.04
     env:
-      GO_VERSION: "1.22"
+      GO_VERSION: "1.23"
       IMAGE_REGISTRY: quay.io/rh-marketplace
     defaults:
       run:
@@ -20,7 +20,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: ^1.22
+        go-version: ^1.23
         cache: false
       id: go
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -164,7 +164,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -302,7 +302,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -439,7 +439,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3

--- a/.github/workflows/release_status.yml
+++ b/.github/workflows/release_status.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.22"
+        go-version: "1.23"
         cache: false
     - name: Cache Go modules
       uses: actions/cache@v3

--- a/airgap/v2/go.mod
+++ b/airgap/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/airgap/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	emperror.dev/errors v0.8.1

--- a/authchecker/v2/go.mod
+++ b/authchecker/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/authchecker/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS
 ENV TZ=America/New_York
 ENV PATH=$PATH:/opt/app-root/src/go/bin CGO_ENABLED=1
-ARG GRPC_HEALTH_VERSION=v0.4.34
+ARG GRPC_HEALTH_VERSION=v0.4.37
 ARG DQLITE_VERSION=v1.18.0
 ARG LIBUV_VERSION=v1.49.2
 ARG quay_expiration=7d

--- a/cue.mod/go.mod
+++ b/cue.mod/go.mod
@@ -1,5 +1,5 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/cue.mod
 
-go 1.22
+go 1.23
 
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.5.0

--- a/datareporter/v2/go.mod
+++ b/datareporter/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/datareporter/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	dario.cat/mergo v1.0.0

--- a/datareporter/v2/hack/opm-builder.Dockerfile
+++ b/datareporter/v2/hack/opm-builder.Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS
 
 WORKDIR /build
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.34 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.37 && \
     curl --retry 5 -L "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o grpc_health_probe  && \
     chmod +x ./grpc_health_probe
 

--- a/metering/v2/go.mod
+++ b/metering/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/metering/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	emperror.dev/errors v0.8.1

--- a/reporter/v2/go.mod
+++ b/reporter/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/reporter/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	emperror.dev/errors v0.8.1

--- a/utils.Makefile
+++ b/utils.Makefile
@@ -11,7 +11,7 @@ export TAG
 
 BINDIR ?= ./bin
 # GO_VERSION can be major version only, latest stable minor version will be retrieved by base.Dockerfile
-GO_VERSION ?= 1.22
+GO_VERSION ?= 1.23
 ENVTEST_K8S_VERSION ?= 1.30.x
 ARCHS ?= amd64 ppc64le s390x arm64
 BUILDX ?= true

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	emperror.dev/errors v0.8.1

--- a/v2/hack/opm-builder.Dockerfile
+++ b/v2/hack/opm-builder.Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS
 
 WORKDIR /build
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.34 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.37 && \
     curl --retry 5 -L "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o grpc_health_probe  && \
     chmod +x ./grpc_health_probe
 

--- a/v2/scripts/go.mod
+++ b/v2/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/tooling
 
-go 1.22
+go 1.23
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/v2/tools/connect/go.mod
+++ b/v2/tools/connect/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/v2/tools/connect
 
-go 1.22
+go 1.23
 
 require (
 	emperror.dev/errors v0.8.1

--- a/v2/tools/version/go.mod
+++ b/v2/tools/version/go.mod
@@ -1,8 +1,8 @@
 module github.com/redhat-marketplace/redhat-marketplace-operator/v2/tools/version
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.9
+toolchain go1.23.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
- update to go1.23
- update grpc-health-probe to v0.4.37
- Builder available: https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690?image=67f7e5d0639042b2fe77b475

This is likely to fail checks as the base builder will not be updated to 1.23 until after merge