### PR TITLE
fix: update base to go1.24.4 and grpc-health-probe v0.4.39

### DIFF
--- a/base/dataservice.Dockerfile
+++ b/base/dataservice.Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS
 ENV TZ=America/New_York
 ENV PATH=$PATH:/opt/app-root/src/go/bin CGO_ENABLED=1
-ARG GRPC_HEALTH_VERSION=v0.4.37
+ARG GRPC_HEALTH_VERSION=v0.4.39
 ARG DQLITE_VERSION=v1.18.0
 ARG LIBUV_VERSION=v1.49.2
 ARG quay_expiration=7d

--- a/datareporter/v2/hack/opm-builder.Dockerfile
+++ b/datareporter/v2/hack/opm-builder.Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS
 
 WORKDIR /build
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.37 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
     curl --retry 5 -L "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o grpc_health_probe  && \
     chmod +x ./grpc_health_probe
 

--- a/v2/hack/opm-builder.Dockerfile
+++ b/v2/hack/opm-builder.Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETOS
 
 WORKDIR /build
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.37 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.39 && \
     curl --retry 5 -L "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH}" -o grpc_health_probe  && \
     chmod +x ./grpc_health_probe
 


### PR DESCRIPTION
update the builder before further updates
https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690?image=6889ce5dee7543aa1f81d24d