### PR TITLE
Feature: Add a StorageClassName to the MarketplaceConfig & MeterBase Spec

### DIFF
--- a/utils.Makefile
+++ b/utils.Makefile
@@ -4,7 +4,7 @@ space := $(subst ,, )
 UNAME_S := $(shell uname -s)
 UNAME := $(shell echo `uname` | tr '[:upper:]' '[:lower:]')
 
-VERSION ?= $(shell $(SVU) next --prefix "")
+
 TAG ?= $(VERSION)
 export VERSION
 export TAG
@@ -19,6 +19,8 @@ ARCH ?= amd64
 IMAGE_PUSH ?= true
 DOCKER_BUILD := docker build
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+SVU=$(PROJECT_DIR)/bin/svu
+VERSION ?= $(shell $(SVU) next --prefix "")
 DOCKERBUILDXCACHE ?=
 
 KUBE_RBAC_PROXY_IMAGE ?= registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.17

--- a/v2/apis/marketplace/v1alpha1/marketplaceconfig_types.go
+++ b/v2/apis/marketplace/v1alpha1/marketplaceconfig_types.go
@@ -84,6 +84,15 @@ type MarketplaceConfigSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Authorize Automatic Account Creation"
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
 	AuthorizeAccountCreation *bool `json:"authorizeAccountCreation,omitempty"`
+
+	// storageClassName is the name of the StorageClass required by the claim.
+	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Storage Class Name"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="text"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +optional
+	StorageClassName *string `json:"storageClassName,omitempty" protobuf:"bytes,5,opt,name=storageClassName"`
 }
 
 // MarketplaceConfigStatus defines the observed state of MarketplaceConfig

--- a/v2/apis/marketplace/v1alpha1/meterbase_types.go
+++ b/v2/apis/marketplace/v1alpha1/meterbase_types.go
@@ -121,6 +121,15 @@ type MeterBaseSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.statusDescriptors=true
 	// +optional
 	UserWorkloadMonitoringEnabled *bool `json:"userWorkloadMonitoringEnabled,omitempty"`
+
+	// storageClassName is the name of the StorageClass required by the claim.
+	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.displayName="Storage Class Name"
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors.x-descriptors="text"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
+	// +optional
+	StorageClassName *string `json:"storageClassName,omitempty" protobuf:"bytes,5,opt,name=storageClassName"`
 }
 
 func (m *MeterBaseSpec) IsDataServiceEnabled() bool {

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -510,6 +510,7 @@ func (r *MarketplaceConfigReconciler) createOrUpdateMeterBase(request reconcile.
 		meterBase = utils.BuildMeterBaseCr(
 			request.Namespace,
 			!ptr.ToBool(marketplaceConfig.Spec.IsDisconnected) && ptr.ToBool(marketplaceConfig.Spec.Features.EnableMeterDefinitionCatalogServer),
+			marketplaceConfig.Spec.StorageClassName,
 		)
 
 		if err = controllerutil.SetControllerReference(marketplaceConfig, meterBase, r.Scheme); err != nil {

--- a/v2/controllers/marketplace/marketplaceconfig_controller.go
+++ b/v2/controllers/marketplace/marketplaceconfig_controller.go
@@ -264,6 +264,11 @@ func (r *MarketplaceConfigReconciler) handleMeterDefinitionCatalogServerConfigs(
 			}
 		}
 
+		// storageClassName set once, otherwise immutable
+		if meterBase.Spec.StorageClassName == nil {
+			meterBase.Spec.StorageClassName = marketplaceConfig.Spec.StorageClassName
+		}
+
 		if !reflect.DeepEqual(meterBaseCopy.Spec, meterBase.Spec) {
 			reqLogger.Info("updating meterbase")
 			return r.Client.Update(context.TODO(), meterBase)

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -747,18 +747,18 @@ func (f *Factory) UpdateDataServiceService(s *corev1.Service) error {
 	return nil
 }
 
-func (f *Factory) NewDataServiceStatefulSet() (*appsv1.StatefulSet, error) {
+func (f *Factory) NewDataServiceStatefulSet(storageClassName *string) (*appsv1.StatefulSet, error) {
 	sts, err := f.NewStatefulSet(MustAssetReader(DataServiceStatefulSet))
 	if err != nil {
 		return nil, err
 	}
 
-	f.UpdateDataServiceStatefulSet(sts)
+	f.UpdateDataServiceStatefulSet(sts, storageClassName)
 
 	return sts, nil
 }
 
-func (f *Factory) UpdateDataServiceStatefulSet(sts *appsv1.StatefulSet) error {
+func (f *Factory) UpdateDataServiceStatefulSet(sts *appsv1.StatefulSet, storageClassName *string) error {
 	sts2, err := f.NewStatefulSet(MustAssetReader(DataServiceStatefulSet))
 	if err != nil {
 		return err
@@ -782,6 +782,11 @@ func (f *Factory) UpdateDataServiceStatefulSet(sts *appsv1.StatefulSet) error {
 		}
 
 		container.Args = newArgs
+	}
+
+	for i := range sts.Spec.VolumeClaimTemplates {
+		volumeClaimTemplate := &sts.Spec.VolumeClaimTemplates[i]
+		volumeClaimTemplate.Spec.StorageClassName = storageClassName
 	}
 
 	// Inject the SubscriptionConfig overrides

--- a/v2/pkg/utils/k8s.go
+++ b/v2/pkg/utils/k8s.go
@@ -246,7 +246,7 @@ func UpdateMeterDefinitionCatalogConfig(
 }
 
 // BuildMeterBaseCr returns a MeterBase cr with default values
-func BuildMeterBaseCr(namespace string, deployMdefCatalogServer bool) *marketplacev1alpha1.MeterBase {
+func BuildMeterBaseCr(namespace string, deployMdefCatalogServer bool, storageClassName *string) *marketplacev1alpha1.MeterBase {
 	cr := &marketplacev1alpha1.MeterBase{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      METERBASE_NAME,
@@ -260,6 +260,7 @@ func BuildMeterBaseCr(namespace string, deployMdefCatalogServer bool) *marketpla
 				},
 			},
 			MeterdefinitionCatalogServerConfig: NewMeterDefinitionCatalogConfig(deployMdefCatalogServer),
+			StorageClassName:                   storageClassName,
 		},
 	}
 	return cr

--- a/v2/pkg/utils/k8s_test.go
+++ b/v2/pkg/utils/k8s_test.go
@@ -212,12 +212,13 @@ var _ = Describe("Testing with Ginkgo", func() {
 	})
 })
 var (
-	namespace             = "redhat-marketplace-operator"
-	customerID     string = "example-userid"
-	testNamespace1        = "testing-namespace-1"
-	testNamespace2        = "testing-namespace-2"
-	testNamespace3        = "testing-namespace-3"
-	features              = &common.Features{
+	namespace               = "redhat-marketplace-operator"
+	customerID       string = "example-userid"
+	testNamespace1          = "testing-namespace-1"
+	testNamespace2          = "testing-namespace-2"
+	testNamespace3          = "testing-namespace-3"
+	storageClassName        = "rook-ceph"
+	features                = &common.Features{
 		Deployment:                         ptr.Bool(true),
 		EnableMeterDefinitionCatalogServer: ptr.Bool(true),
 	}
@@ -233,7 +234,7 @@ var (
 
 func setup() client.Client {
 	marketplaceconfig.Spec.Features = features
-	meterbase = BuildMeterBaseCr(testNamespace1, *marketplaceconfig.Spec.Features.EnableMeterDefinitionCatalogServer)
+	meterbase = BuildMeterBaseCr(testNamespace1, *marketplaceconfig.Spec.Features.EnableMeterDefinitionCatalogServer, &storageClassName)
 	defaultFeatures := []string{"meterbase"}
 	viper.Set("features", defaultFeatures)
 	testNs1.ObjectMeta.Name = testNamespace1


### PR DESCRIPTION
Chore

- reorder some items in utils.Makefile that were causing variable resolution issues

Feature

Add a StorageClassName to the MarketplaceConfig & MeterBase Spec

The linting/admission-control tool Kyverna fails on empty StatefulSet.Spec.VolumeClaimTemplates.[].StorageClassName
Despite that this can be specified via a defaultStorageClass, pre-defined PhysicalVolumeClaims, or when manually allocation PersistentVolumes.

- Provide a spec.storageClassName on MarketplaceConfig. This is an immutable field that will set the spec.volumeClaimTemplates.[].storageClass on the data-service StatefulSet, which is also immutable
- If the StatefulSet exists, the reconciler will use the existing immutable value
- If the PersistentVolumeClaims are already created, the reconciler will use its value
- If MarketplaceConfig sets the storageClassName at creation, the reconciler will use the MarketplaceConfig value (via MeterBase)
- If a defaultStorageClass is available, the reconciler will use its value