### PR TITLE
feat: updates for kyverno policies

### DIFF
--- a/datareporter/v2/config/manager/manager.yaml
+++ b/datareporter/v2/config/manager/manager.yaml
@@ -77,7 +77,7 @@ spec:
             drop:
               - "ALL"
           privileged: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
         env:
         - name: POD_NAMESPACE
@@ -114,5 +114,12 @@ spec:
           - containerPort: 8443
             protocol: TCP
             name: https
+        volumeMounts:
+        - name: tmp
+          mountPath: "/tmp"
+      volumes:
+      - name: tmp
+        emptyDir:
+          sizeLimit: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/v2/assets/dataservice/pdb.yaml
+++ b/v2/assets/dataservice/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: rhm-data-service
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: rhm-data-service

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -48,14 +48,18 @@ spec:
                     - rhm-data-service
             topologyKey: topology.kubernetes.io/zone
       topologySpreadConstraints:
-      - topologyKey: kubernetes.io/hostname
+      - maxSkew: 1
+        whenUnsatisfiable: ScheduleAnyway
+        topologyKey: kubernetes.io/hostname
         labelSelector:
           matchExpressions:
           - key: app
             operator: In
             values:
               - rhm-data-service
-      - topologyKey: topology.kubernetes.io/zone
+      - maxSkew: 1
+        whenUnsatisfiable: ScheduleAnyway
+        topologyKey: topology.kubernetes.io/zone
         labelSelector:
           matchExpressions:
           - key: app

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -135,6 +135,24 @@ spec:
                 containerName: authcheck
                 resource: limits.memory
           terminationMessagePolicy: FallbackToLogsOnError
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 28088
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 28088
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
         - args:
             - --secure-listen-address=:8004
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -183,6 +201,24 @@ spec:
             - mountPath: /etc/tls/mtls
               name: rhm-data-service-mtls
               readOnly: false
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8004
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8004
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
         - args:
             - --secure-listen-address=:8008
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
@@ -230,7 +266,24 @@ spec:
             - mountPath: /etc/tls/mtls
               name: rhm-data-service-mtls
               readOnly: false
-
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8008
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8008
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: rhm-data-service-tls
           secret:

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
                 values:
                 - linux
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
@@ -86,6 +86,11 @@ spec:
             initialDelaySeconds: 360
             periodSeconds: 5
             timeoutSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 9001
+            initialDelaySeconds: 15
+            periodSeconds: 10
           ports:
             - containerPort: 9001
               name: db

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -47,6 +47,23 @@ spec:
                   values:
                     - rhm-data-service
             topologyKey: topology.kubernetes.io/zone
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - rhm-data-service
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - rhm-data-service
       terminationGracePeriodSeconds: 45
       securityContext: 
         runAsNonRoot: true

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -202,19 +202,15 @@ spec:
               name: rhm-data-service-mtls
               readOnly: false
           readinessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: 8004
-              scheme: HTTPS
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: 8004
-              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
@@ -267,19 +263,15 @@ spec:
               name: rhm-data-service-mtls
               readOnly: false
           readinessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: 8008
-              scheme: HTTPS
             initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: 8008
-              scheme: HTTPS
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -48,16 +48,14 @@ spec:
                     - rhm-data-service
             topologyKey: topology.kubernetes.io/zone
       topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: kubernetes.io/hostname
+      - topologyKey: kubernetes.io/hostname
         labelSelector:
           matchExpressions:
           - key: app
             operator: In
             values:
               - rhm-data-service
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
+      - topologyKey: topology.kubernetes.io/zone
         labelSelector:
           matchExpressions:
           - key: app

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -33,17 +33,13 @@ spec:
                 - linux
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - rhm-data-service
-                namespaces:
-                  - redhat-marketplace
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - rhm-data-service
+            topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 45
       securityContext: 
         runAsNonRoot: true

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -153,6 +153,14 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
         - args:
             - --secure-listen-address=:8004
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -47,23 +47,23 @@ spec:
                   values:
                     - rhm-data-service
             topologyKey: topology.kubernetes.io/zone
-        topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-                - rhm-data-service
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          labelSelector:
-            matchExpressions:
-            - key: app
-              operator: In
-              values:
-                - rhm-data-service
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - rhm-data-service
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - rhm-data-service
       terminationGracePeriodSeconds: 45
       securityContext: 
         runAsNonRoot: true

--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -40,6 +40,13 @@ spec:
                   values:
                     - rhm-data-service
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                    - rhm-data-service
+            topologyKey: topology.kubernetes.io/zone
       terminationGracePeriodSeconds: 45
       securityContext: 
         runAsNonRoot: true

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -61,7 +61,7 @@ spec:
                 drop:
                 - ALL
               privileged: false
-              readOnlyRootFilesystem: false
+              readOnlyRootFilesystem: true
               runAsNonRoot: true
             resources:
               requests:
@@ -70,3 +70,9 @@ spec:
               limits:
                 cpu: 1
                 memory: 4Gi
+            volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          volumes:
+          - name: tmp
+            emptyDir: {}

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -63,3 +63,10 @@ spec:
               privileged: false
               readOnlyRootFilesystem: false
               runAsNonRoot: true
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: 1
+                memory: 4Gi

--- a/v2/assets/reporter/cronjob.yaml
+++ b/v2/assets/reporter/cronjob.yaml
@@ -72,7 +72,8 @@ spec:
                 memory: 4Gi
             volumeMounts:
             - name: tmp
-              mountPath: /tmp
+              mountPath: "/tmp"
           volumes:
           - name: tmp
-            emptyDir: {}
+            emptyDir:
+              sizeLimit: 256Mi

--- a/v2/controllers/marketplace/dataservice_controller.go
+++ b/v2/controllers/marketplace/dataservice_controller.go
@@ -139,6 +139,13 @@ func (r *DataServiceReconciler) Reconcile(ctx context.Context, request reconcile
 			return reconcile.Result{}, err
 		}
 
+		/* DataService PodDisruptionBudget */
+		if err := r.Factory.CreateOrUpdate(r.Client, meterBase, func() (client.Object, error) {
+			return r.Factory.NewDataServicePodDisruptionBudget()
+		}); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		/* DataService Service */
 		if err := r.Factory.CreateOrUpdate(r.Client, meterBase, func() (client.Object, error) {
 			return r.Factory.NewDataServiceService()
@@ -210,6 +217,18 @@ func (r *DataServiceReconciler) Reconcile(ctx context.Context, request reconcile
 
 		if err = r.Client.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
 			reqLogger.Error(err, "Delete Secret error: ")
+			return reconcile.Result{}, err
+		}
+
+		/* DataService PodDisruptionBudget */
+		pdb, err := r.Factory.NewDataServicePodDisruptionBudget()
+		if err != nil {
+			reqLogger.Error(err, "data service poddisruptionbudget error")
+			return reconcile.Result{}, err
+		}
+
+		if err := r.Client.Delete(ctx, pdb); err != nil && !errors.IsNotFound(err) {
+			reqLogger.Error(err, "Delete PodDisruptionBudget error: ")
 			return reconcile.Result{}, err
 		}
 	}

--- a/v2/controllers/marketplace/dataservice_controller.go
+++ b/v2/controllers/marketplace/dataservice_controller.go
@@ -32,6 +32,7 @@ import (
 	marketplacev1alpha1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -77,6 +78,10 @@ func (r *DataServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&routev1.Route{},
 			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &marketplacev1alpha1.MeterBase{}, handler.OnlyControllerOwner()),
+			builder.WithPredicates(namespacePredicate)).
+		Watches(
+			&policyv1.PodDisruptionBudget{},
+			handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &marketplacev1alpha1.MeterBase{}, handler.OnlyControllerOwner()),
 			builder.WithPredicates(namespacePredicate)).Complete(r)
 }
 
@@ -90,6 +95,7 @@ func (r *DataServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="route.openshift.io",namespace=system,resources=routes,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="route.openshift.io",namespace=system,resources=routes,verbs=patch;update;delete,resourceNames=rhm-data-service
 // +kubebuilder:rbac:groups="storage.k8s.io",resources=storageclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups="policy",namespace=system,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a MeterBase object and makes changes based on the state read
 // and what is in the MeterBase.Spec

--- a/v2/main.go
+++ b/v2/main.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -207,6 +208,9 @@ func main() {
 				Namespaces: nsScopePod,
 			},
 			&batchv1.Job{}: {
+				Namespaces: nsScopePod,
+			},
+			&policyv1.PodDisruptionBudget{}: {
 				Namespaces: nsScopePod,
 			},
 			&marketplacev1alpha1.MarketplaceConfig{}: {

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gotidy/ptr"
 	osappsv1 "github.com/openshift/api/apps/v1"
 	osimagev1 "github.com/openshift/api/image/v1"
-	policyv1 "github.com/openshift/api/policy/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	marketplacev1beta1 "github.com/redhat-marketplace/redhat-marketplace-operator/v2/apis/marketplace/v1beta1"
@@ -41,6 +40,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -603,7 +603,7 @@ func (f *Factory) UpdateRoute(manifest io.Reader, r *routev1.Route) error {
 	return nil
 }
 
-func (f *Factory) NewPodDisruptionBudget(manifest io.Reader) (*policyv1.Route, error) {
+func (f *Factory) NewPodDisruptionBudget(manifest io.Reader) (*policyv1.PodDisruptionBudget, error) {
 	p, err := NewPodDisruptionBudget(manifest)
 	if err != nil {
 		return nil, err
@@ -939,7 +939,7 @@ func NewRoute(manifest io.Reader) (*routev1.Route, error) {
 	return &r, nil
 }
 
-func NewPodDisruptionBudget(manifest io.Reader) (*policyv1.Route, error) {
+func NewPodDisruptionBudget(manifest io.Reader) (*policyv1.PodDisruptionBudget, error) {
 	p := policyv1.PodDisruptionBudget{}
 	err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&p)
 	if err != nil {

--- a/v2/pkg/manifests/factory.go
+++ b/v2/pkg/manifests/factory.go
@@ -613,6 +613,9 @@ func (f *Factory) NewPodDisruptionBudget(manifest io.Reader) (*policyv1.PodDisru
 		p.SetNamespace(f.namespace)
 	}
 
+	minAvailable := intstr.FromInt32(int32(f.operatorConfig.DataServiceReplicas)/2 + 1)
+	p.Spec.MinAvailable = &minAvailable
+
 	return p, nil
 }
 
@@ -621,6 +624,9 @@ func (f *Factory) UpdatePodDisruptionBudget(manifest io.Reader, p *policyv1.PodD
 	if err != nil {
 		return err
 	}
+
+	minAvailable := intstr.FromInt32(int32(f.operatorConfig.DataServiceReplicas)/2 + 1)
+	p.Spec.MinAvailable = &minAvailable
 
 	return nil
 }


### PR DESCRIPTION
Modifications to comply with the following policy sets

https://github.ibm.com/CloudPakOpenContent/ford-caas-audit/tree/main/policies
https://github.com/ibm-mas/kyverno-policies

- Require Read-Only Root Filesystem
  - Update datareporter-operator to set readOnlyRootFilesystem: true
  - Update reporter cronjob to set readOnlyRootFilesystem: true
  
- Restrict EmptyDir Volume Types
  - Update datareporter-operator
    - Mount a emptyDir tmp with a sizeLimit, where reports are temporarily written to 
  - Update reporter cronjob
    - Mount a emptyDir tmp with a sizeLimit, where reports are temporarily written to 

- Require PodDisruptionBudget
  - data-service should retain a quorum of N/2 + 1 (default: 3 replicas, 2 minAvailable)
  - Add PodDisruptionBudget CRUD to dataservice operator
    - Add Watch
	- Add to Create and Delete lifecycle
  - Add PodDisruptionBudget to operator listener object cache, namespace scope
  - Add PodDisruptionBudget to factory
    - update minAvailable based on replica configuration N/2 + 1

- require-topologyspread-or-affinity
  - Use required pod anti-affinity rules (requiredDuringSchedulingIgnoredDuringExecution) instead of preferredDuringSchedulingIgnoredDuringExecution
  - Add topology.kubernetes.io/zone topologyKey

- Require-Topologyspreadconstraints
  - Use required pod topologyspreadconstraints rules 
  - Add kubernetes.io/hostname topology.kubernetes.io/zone topologyKeys

- require-pod-probes
  - add readinessProbe and livenessProbe to all data-service containers where missing
  
- require-requests-limits
  - add requests & limits to reporter cronjob
