### PR TITLE
bugfix: cleanup bad affinity rule

### DIFF
--- a/v2/assets/dataservice/statefulset.yaml
+++ b/v2/assets/dataservice/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
                       operator: In
                       values:
                         - rhm-data-service
-                topologyKey: kubernetes.io/zone
+                topologyKey: topology.kubernetes.io/zone
             - weight: 50
               podAffinityTerm:
                 labelSelector:


### PR DESCRIPTION
- fix: topologykey should be `topology.kubernetes.io/zone` not `kubernetes.io/zone`
- fix: Upgrading from 2.21.0 leaves the PodAntiAffinity RequiredDuringSchedulingIgnoredDuringExecution rules in place in the array, since the default reconciler factory action is a merge strategy. This lead to some pods not starting in upgraded single node environments.
  - Add specific logic to remove RequiredDuringSchedulingIgnoredDuringExecution rules
  - Add specific logic to restart the pods stuck in Pending state, a workaround to k8s bug 120123