### PR TITLE
Chore/cleanup job

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,5 +1,9 @@
 # Cleanup docker images and tmp
 name: Cleanup
+on:
+  workflow_dispatch: {}
+  schedule:
+  - cron: 0 0 1 * *
 jobs:
   cleanup:
     name: Cleanup


### PR DESCRIPTION
Add a monthly cron job to cleanup runner VM
Seeing `System.IO.IOException: No space left on device` on some builds 